### PR TITLE
ci: use layer specific cache folders

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -8,9 +8,9 @@ on:
         value: ${{ jobs.create-output.outputs.url }}
 
 env:
-  CACHE_DIR: /efs/qli/meta-qcom
-  KAS_REPO_REF_DIR: /efs/qli/meta-qcom/kas-mirrors
-  KAS_CONTAINER: /efs/qli/meta-qcom/kas-mirrors/kas-container
+  CACHE_DIR: /efs/qli/meta-qcom-robotics-sdk
+  KAS_REPO_REF_DIR: /efs/qli/meta-qcom-robotics-sdk/kas-mirrors
+  KAS_CONTAINER: /efs/qli/meta-qcom-robotics-sdk/kas-mirrors/kas-container
 
 jobs:
   kas-setup:


### PR DESCRIPTION
/efs/qli/xxx is a persistent folder managed by our IT infra, we use it to keep file across builds. This layer should use its own set of cache data, instead of using/overriding the content of the cache used by the meta-qcom layer.