### PR TITLE
test: set head_sha to not required in test.yaml

### DIFF
--- a/.github/workflows/publish-results.yml
+++ b/.github/workflows/publish-results.yml
@@ -1,0 +1,66 @@
+name: Publish test results
+
+on:
+  workflow_call:
+    inputs:
+      workflow_id:
+        required: true
+        type: string
+      event_name:
+        required: true
+        type: string
+      event_file:
+        required: true
+        type: string
+      commit:
+        required: true
+        type: string
+
+permissions:
+  checks: write
+  pull-requests: write
+  contents: read
+  packages: read
+
+jobs:
+  publish-test-results:
+    name: "Publish Tests Results"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download result files
+        uses: actions/download-artifact@v6
+        with:
+            run-id: ${{ inputs.workflow_id }}
+            path: artifacts
+            github-token: ${{ github.token }}
+
+      - name: Download result files PR
+        if: ${{ github.run_id != inputs.workflow_id }}
+        uses: actions/download-artifact@v6
+        with:
+            path: artifacts
+            github-token: ${{ github.token }}
+
+      - name: "List files"
+        run: |
+          echo $GITHUB_WORKSPACE
+          ls -R $GITHUB_WORKSPACE
+
+      - id: app_token
+        uses: actions/create-github-app-token@v2
+        if: always()
+        with:
+          app-id: 2291458
+          private-key: ${{ secrets.TEST_REPORTING_APP_TOKEN }}
+
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()
+        with:
+          commit: ${{ inputs.commit }}
+          event_file: ${{ inputs.event_file}}
+          event_name: ${{ inputs.event_name }}
+          files: "${{ github.workspace }}/artifacts/**/*.xml"
+          action_fail: true
+          action_fail_on_inconclusive: true
+          github_token: ${{ steps.app_token.outputs.token }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
         required: true
         type: string
       head_sha:
-        required: true
+        required: false
         type: string
 
 jobs:


### PR DESCRIPTION
- Import workflow from meta-qcom to surface CI test results.
- Set head_sha to not required in test.yaml