### PR TITLE
fix: resolve ros-gst-bridge configuration error in Mar 5 nightly build

### DIFF
--- a/ci/base.yml
+++ b/ci/base.yml
@@ -3,7 +3,7 @@
 header:
   version: 14
 
-distro: poky-altcfg
+distro: nodistro
 
 defaults:
   repos:
@@ -11,8 +11,6 @@ defaults:
 
 repos:
   meta-qcom:
-    url: "https://github.com/qualcomm-linux/meta-qcom.git"
-    branch: master
 
   oe-core:
     url: https://github.com/openembedded/openembedded-core
@@ -24,27 +22,48 @@ repos:
     layers:
       .: disabled
 
-  meta-yocto:
-    url: https://git.yoctoproject.org/meta-yocto
-    layers:
-      meta-poky:
-
 local_conf_header:
   base: |
     CONF_VERSION = "2"
     INHERIT += "buildstats-summary"
     INHERIT += "buildhistory"
     INHERIT += "rm_work"
+    INHERIT += "image-buildinfo"
+  diskmon: |
+    BB_DISKMON_DIRS ??= "\
+      STOPTASKS,${TMPDIR},1G,100K \
+      STOPTASKS,${DL_DIR},1G,100K \
+      STOPTASKS,${SSTATE_DIR},1G,100K \
+      STOPTASKS,/tmp,100M,100K \
+      HALT,${TMPDIR},100M,1K \
+      HALT,${DL_DIR},100M,1K \
+      HALT,${SSTATE_DIR},100M,1K \
+      HALT,/tmp,10M,1K"
+  clo-mirrors: |
+    # clo-mirrors
+    MIRRORS:append = " \
+    git://github.com git://git.codelinaro.org/clo/yocto-mirrors/github/ \
+    git://.*/ git://git.codelinaro.org/clo/yocto-mirrors/ \
+    https://.*/.*/ https://artifacts.codelinaro.org/codelinaro-le/ \
+    "
+    # All the download files of meta-qcom layer have been deployed on this server.
+    PREMIRRORS:prepend = "\
+    .*://.*/.* https://artifacts.codelinaro.org/artifactory/qli-ci/downloads/main/ \n \
+    "
   cmdline: |
     KERNEL_CMDLINE_EXTRA:append = " qcom_scm.download_mode=1"
   qcomflash: |
     IMAGE_CLASSES += "image_types_qcom"
     IMAGE_FSTYPES += "qcomflash"
   extra: |
-    DISTRO_FEATURES:append = " efi pni-names"
+    DISTRO_FEATURES:append = " efi pam pni-names"
     EXTRA_IMAGE_FEATURES = "allow-empty-password empty-root-password allow-root-login"
     IMAGE_ROOTFS_EXTRA_SPACE = "307200"
     WATCHDOG_RUNTIME_SEC:pn-systemd = "30"
+  uninative: |
+    INHERIT:remove = "uninative"
+  sstate: |
+    BB_SIGNATURE_HANDLER = "OEBasicHash"
 
 machine: unset
 

--- a/ci/qcom-distro.yml
+++ b/ci/qcom-distro.yml
@@ -37,6 +37,13 @@ repos:
     branch: master
     url: https://github.com/uptane/meta-updater
 
+  meta-security:
+    url: https://git.yoctoproject.org/meta-security
+    branch: master
+    layers:
+      .:
+      meta-tpm:
+
 local_conf_header:
   virtualization:
     SKIP_META_VIRT_SANITY_CHECK = "1"

--- a/ci/qcom-robotics-distro.yml
+++ b/ci/qcom-robotics-distro.yml
@@ -9,9 +9,8 @@ repos:
   meta-qcom-robotics-sdk:
 
   meta-qcom:
-      url: https://github.com/qualcomm-linux/meta-qcom.git
-      branch: master
-      commit: 5c1e91fcbb9bb2149c89e395acc8e19869d43a8a
+      url: https://github.com/qualcomm-linux/meta-qcom
+      commit: 3b2c2c8b815e135a01db7b6a77e3a0c57048bca8
   oe-core:
       url: https://github.com/openembedded/openembedded-core
       layers:
@@ -20,21 +19,16 @@ repos:
           fix-BSD-license-missing:
               repo: meta-qcom-robotics-sdk
               path: patches/Initial-commit-of-license.patch
-      commit: 4c31a7b410fc9c14815c6853431c7bd56c0e173c
+      commit: d3e757f21403554e7064c5fa2b353080d14d2ce7
   bitbake:
       url: https://github.com/openembedded/bitbake
       layers:
           .: disabled
-      commit: cdd79c1768ac396a9c6577e38098da4331507f24
-  meta-yocto:
-      url: https://git.yoctoproject.org/meta-yocto
-      layers:
-          meta-poky:
-      commit: de4abc0a175af12eacc761a2e1e60ca7fdfeaa1b
+      commit: 48efc36b4e03f736e7521d269ced3417522784e9
   meta-qcom-distro:
       url: https://github.com/qualcomm-linux/meta-qcom-distro
       branch: main
-      commit: 9754815d7eeb95e68db943dbae342496a586f53f
+      commit: 98e83ead3caa95184d2a37e02b4b6928caa754a4
   meta-openembedded:
       url: https://github.com/openembedded/meta-openembedded
       layers:
@@ -45,23 +39,30 @@ repos:
           meta-oe:
           meta-python:
           meta-xfce:
-      commit: dfd6cf901aa530eb924ed62ad2498f8abf43fed2
+      commit: 7bc5268662f1428bdbca08e14d223aa6b62e87f3
   meta-virtualization:
       url: https://git.yoctoproject.org/git/meta-virtualization
       branch: master
-      commit: 28d26fd95397bf575e65fcca0cbb302b1e9bc7ff
+      commit: a1e1a021b49f5257d8908aa9b8c2ee9c083e674c
   meta-audioreach:
       url: https://github.com/AudioReach/meta-audioreach
       branch: master
-      commit: f864c62336a771b05b6d1e03a1092ddd286f4038
+      commit: 7cd6eeb2c6bfda35a622df9a37eb5bbf0371253e
   meta-selinux:
       branch: master
       url: https://git.yoctoproject.org/meta-selinux
-      commit: d670531ad7e6cd0dac08010fbd9b604501391245
+      commit: 27758bca5ad8f74f387de5cc7c88e73ef2aed951
   meta-updater:
       branch: master
       url: https://github.com/uptane/meta-updater
-      commit: 1e9ec9b9c10bd16c018bf5440ed6ffc56789dab0
+      commit: 9fb4d7e2c087511d3dff233ebd342f35facf4cde
+  meta-security:
+      url: https://git.yoctoproject.org/meta-security
+      branch: master
+      layers:
+          .:
+          meta-tpm:
+      commit: 9e6d962250aab6e5319215f15b0201ef233c46cd
 
   meta-ros:
       url: https://github.com/ros/meta-ros.git
@@ -83,16 +84,7 @@ repos:
       commit: fceba46917fe9473e64534d972d3cf853aa7674d
 
 local_conf_header:
-  base: |
-    CONF_VERSION = "2"
-    INHERIT += "buildstats-summary"
-    INHERIT += "buildhistory"
-    INHERIT += "rm_work"
-    
-    # Disable the libcamera recipe to avoid conflicts with the meta-qcom-distro libcamera recipe
-    BBMASK .= "|^${TOPDIR}/meta-ros/meta-ros-common/recipes-multimedia/libcamera/.*"
-    PREFERRED_VERSION_libcamera = "1:0.6.0"
-    
+  resource_limitation: |   
     # Capture the count of cpu cores available from the host.
     CPU_COUNT = "${@oe.utils.cpu_count(at_least=2)}"
 
@@ -116,19 +108,10 @@ local_conf_header:
 
     # Determines how many processes make should run in parallel when running compile tasks.
     PARALLEL_MAKE ?= "-j ${THREAD_COUNT} -l ${THREAD_COUNT}"
-
-  cmdline: |
-    KERNEL_CMDLINE_EXTRA:append = " qcom_scm.download_mode=1"
-  qcomflash: |
-    IMAGE_CLASSES += "image_types_qcom"
-    IMAGE_FSTYPES += "qcomflash"
-  extra: |
-    DISTRO_FEATURES:append = " efi pni-names"
-    EXTRA_IMAGE_FEATURES = "allow-empty-password empty-root-password allow-root-login"
-    IMAGE_ROOTFS_EXTRA_SPACE = "307200"
-    WATCHDOG_RUNTIME_SEC:pn-systemd = "30"
-  robotics_base: |
-    PATCHRESOLVE = "noop"
+  libcamera_mask: |
+    # Disable the libcamera recipe to avoid conflicts with the meta-qcom-distro libcamera recipe
+    BBMASK .= "|^${TOPDIR}/meta-ros/meta-ros-common/recipes-multimedia/libcamera/.*"
+    PREFERRED_VERSION_libcamera = "1:0.6.0"
 
 distro: qcom-robotics-ros2-jazzy
 target: qcom-robotics-image

--- a/recipes/ros-gst-bridge/ros-gst-bridge-audio-msgs_0.0.0.bb
+++ b/recipes/ros-gst-bridge/ros-gst-bridge-audio-msgs_0.0.0.bb
@@ -1,5 +1,6 @@
 inherit ros_distro_${ROS_DISTRO}
 inherit ros_component
+inherit robotics-package
 
 DESCRIPTION = "audio_msgs: subpackage of ros-gst-bridge."
 LICENSE = "Apache-2.0"
@@ -12,8 +13,6 @@ ROS_CN = "audio_msgs"
 ROS_BPN = "audio_msgs"
 
 S = "${UNPACKDIR}/${PN}-${PV}/${ROS_CN}"
-
-inherit robotics-package
 
 ROS_BUILD_TYPE = "ament_cmake"
 inherit ros_${ROS_BUILD_TYPE}
@@ -40,8 +39,8 @@ ROS_TEST_DEPENDS = " \
 
 DEPENDS = "${ROS_BUILD_DEPENDS} ${ROS_BUILDTOOL_DEPENDS}"
 
-EXTRA_OECMAKE += "-DSYSROOT_LIBDIR=${STAGING_LIBDIR}"
-EXTRA_OECMAKE += "-DGST_PLUGINS_QTI_OSS_INSTALL_LIBDIR=${libdir}"
+# EXTRA_OECMAKE += "-DSYSROOT_LIBDIR=${STAGING_LIBDIR}"
+# EXTRA_OECMAKE += "-DGST_PLUGINS_QTI_OSS_INSTALL_LIBDIR=${libdir}"
 
 FILES:${PN} += "${libdir}"
 

--- a/recipes/ros-gst-bridge/ros-gst-bridge-msgs_0.0.0.bb
+++ b/recipes/ros-gst-bridge/ros-gst-bridge-msgs_0.0.0.bb
@@ -1,5 +1,6 @@
 inherit ros_distro_${ROS_DISTRO}
 inherit ros_component
+inherit robotics-package
 
 DESCRIPTION = "gst_msgs: subpackage of ros-gst-bridge."
 LICENSE = "Apache-2.0"
@@ -12,8 +13,6 @@ ROS_CN = "gst_msgs"
 ROS_BPN = "gst_msgs"
 
 S = "${UNPACKDIR}/${PN}-${PV}/${ROS_CN}"
-
-inherit robotics-package
 
 ROS_BUILD_TYPE = "ament_cmake"
 inherit ros_${ROS_BUILD_TYPE}
@@ -40,8 +39,8 @@ ROS_TEST_DEPENDS = " \
 
 DEPENDS = "${ROS_BUILD_DEPENDS} ${ROS_BUILDTOOL_DEPENDS}"
 
-EXTRA_OECMAKE += "-DSYSROOT_LIBDIR=${STAGING_LIBDIR}"
-EXTRA_OECMAKE += "-DGST_PLUGINS_QTI_OSS_INSTALL_LIBDIR=${libdir}"
+# EXTRA_OECMAKE += "-DSYSROOT_LIBDIR=${STAGING_LIBDIR}"
+# EXTRA_OECMAKE += "-DGST_PLUGINS_QTI_OSS_INSTALL_LIBDIR=${libdir}"
 
 FILES:${PN} += "${libdir}"
 

--- a/recipes/ros-gst-bridge/ros-gst-bridge-pipeline-plugins_0.0.0.bb
+++ b/recipes/ros-gst-bridge/ros-gst-bridge-pipeline-plugins_0.0.0.bb
@@ -1,5 +1,6 @@
 inherit ros_distro_${ROS_DISTRO}
 inherit ros_component
+inherit robotics-package
 
 DESCRIPTION = "This package provides a ROS node that hosts a gstreamer pipeline inside a ROS composable node. This is similar to the gscam2 package, but here we use the gst-bridge package for shared-memory IO, allowing this package to focus on supporting features we attach to the pipeline itself."
 LICENSE = "LGPL-3.0-only"
@@ -12,8 +13,6 @@ ROS_CN = "gst_pipeline_plugins"
 ROS_BPN = "gst_pipeline_plugins"
 
 S = "${UNPACKDIR}/${PN}-${PV}/${ROS_CN}"
-
-inherit robotics-package
 
 ROS_BUILD_TYPE = "ament_cmake"
 inherit ros_${ROS_BUILD_TYPE}
@@ -32,6 +31,7 @@ ROS_BUILD_DEPENDS = " \
     ros-gst-bridge-msgs \
     ros-gst-bridge \
     ros-gst-bridge-pipeline \
+    gstreamer1.0 \
     gstreamer1.0-plugins-base \
     image-transport \
     cv-bridge \
@@ -62,12 +62,19 @@ ROS_TEST_DEPENDS = " \
 "
 
 DEPENDS = "${ROS_BUILD_DEPENDS} ${ROS_BUILDTOOL_DEPENDS}"
-DEPENDS += "pkgconfig-native"
+DEPENDS += "pkgconfig-native pkgconfig gstreamer1.0 glib-2.0"
 
-EXTRA_OECMAKE += "-DSYSROOT_LIBDIR=${STAGING_LIBDIR}"
-EXTRA_OECMAKE += "-DGST_PLUGINS_QTI_OSS_INSTALL_LIBDIR=${libdir}"
+do_configure:prepend() {
+    export PKG_CONFIG_SYSROOT_DIR="${RECIPE_SYSROOT}"
+    export PKG_CONFIG_PATH="${RECIPE_SYSROOT}${libdir}/pkgconfig:${RECIPE_SYSROOT}${datadir}/pkgconfig"
+    export PKG_CONFIG_LIBDIR="${RECIPE_SYSROOT}${libdir}/pkgconfig:${RECIPE_SYSROOT}${datadir}/pkgconfig"
+}
+
+# EXTRA_OECMAKE += "-DSYSROOT_LIBDIR=${STAGING_LIBDIR}"
+# EXTRA_OECMAKE += "-DGST_PLUGINS_QTI_OSS_INSTALL_LIBDIR=${libdir}"
+
 # Disable format-security for error: "format not a string literal and no format arguments"
-EXTRA_OECMAKE:append = " -DCMAKE_CXX_FLAGS='-Wno-error=format-security'"
+EXTRA_OECMAKE:append = " -DCMAKE_CXX_FLAGS=-Wno-error=format-security"
 
 # Skip build of tests for QA issues
 INSANE_SKIP:${PN} += "buildpaths"

--- a/recipes/ros-gst-bridge/ros-gst-bridge-pipeline_0.0.0.bb
+++ b/recipes/ros-gst-bridge/ros-gst-bridge-pipeline_0.0.0.bb
@@ -1,5 +1,6 @@
 inherit ros_distro_${ROS_DISTRO}
 inherit ros_component
+inherit robotics-package
 
 DESCRIPTION = "This package provides a ROS node that hosts a gstreamer pipeline inside a ROS composable node. This is similar to the gscam2 package, but here we use the gst-bridge package for shared-memory IO, allowing this package to focus on supporting features we attach to the pipeline itself."
 LICENSE = "LGPL-3.0-only"
@@ -13,8 +14,6 @@ ROS_BPN = "gst_pipeline"
 
 S = "${UNPACKDIR}/${PN}-${PV}/${ROS_CN}"
 
-inherit robotics-package
-
 ROS_BUILD_TYPE = "ament_cmake"
 inherit ros_${ROS_BUILD_TYPE}
 
@@ -24,6 +23,7 @@ ROS_BUILDTOOL_DEPENDS = " \
 "
 
 ROS_BUILD_DEPENDS = " \
+    gstreamer1.0 \
     gstreamer1.0-plugins-base \
     rclcpp \
     rclcpp-components \
@@ -61,12 +61,19 @@ ROS_TEST_DEPENDS = " \
 "
 
 DEPENDS = "${ROS_BUILD_DEPENDS} ${ROS_BUILDTOOL_DEPENDS}"
-DEPENDS += "pkgconfig-native"
+DEPENDS += "pkgconfig-native pkgconfig gstreamer1.0 glib-2.0"
 
-EXTRA_OECMAKE += "-DSYSROOT_LIBDIR=${STAGING_LIBDIR}"
-EXTRA_OECMAKE += "-DGST_PLUGINS_QTI_OSS_INSTALL_LIBDIR=${libdir}"
+do_configure:prepend() {
+    export PKG_CONFIG_SYSROOT_DIR="${RECIPE_SYSROOT}"
+    export PKG_CONFIG_PATH="${RECIPE_SYSROOT}${libdir}/pkgconfig:${RECIPE_SYSROOT}${datadir}/pkgconfig"
+    export PKG_CONFIG_LIBDIR="${RECIPE_SYSROOT}${libdir}/pkgconfig:${RECIPE_SYSROOT}${datadir}/pkgconfig"
+}
+
+# EXTRA_OECMAKE += "-DSYSROOT_LIBDIR=${STAGING_LIBDIR}"
+# EXTRA_OECMAKE += "-DGST_PLUGINS_QTI_OSS_INSTALL_LIBDIR=${libdir}"
+
 # Disable format-security for error: "format not a string literal and no format arguments"
-EXTRA_OECMAKE:append = " -DCMAKE_CXX_FLAGS='-Wno-error=format-security'"
+EXTRA_OECMAKE:append = " -DCMAKE_CXX_FLAGS=-Wno-error=format-security"
 # Skip build of tests for QA issues
 INSANE_SKIP:${PN} += "buildpaths"
 

--- a/recipes/ros-gst-bridge/ros-gst-bridge_0.0.0.bb
+++ b/recipes/ros-gst-bridge/ros-gst-bridge_0.0.0.bb
@@ -1,5 +1,7 @@
 inherit ros_distro_${ROS_DISTRO}
 inherit ros_component
+inherit pkgconfig
+inherit robotics-package
 
 DESCRIPTION = "This ROS package builds gstreamer elements that can be loaded into a gstreamer pipeline. In this package, ROS is treated as a network-transport protocol for video, audio, and text. This package does not build ROS nodes."
 LICENSE = "LGPL-3.0-only"
@@ -13,8 +15,6 @@ ROS_BPN = "gst_bridge"
 
 S = "${UNPACKDIR}/${PN}-${PV}/${ROS_CN}"
 
-inherit robotics-package
-
 ROS_BUILD_TYPE = "ament_cmake"
 inherit ros_${ROS_BUILD_TYPE}
 
@@ -25,9 +25,10 @@ ROS_BUILDTOOL_DEPENDS = " \
 
 ROS_BUILD_DEPENDS = " \
     rclcpp \
-    gstreamer1.0-plugins-base \
     std-msgs \
     sensor-msgs \
+    gstreamer1.0 \
+    gstreamer1.0-plugins-base \
     ros-gst-bridge-audio-msgs \
 "
 
@@ -46,12 +47,20 @@ ROS_TEST_DEPENDS = " \
 "
 
 DEPENDS = "${ROS_BUILD_DEPENDS} ${ROS_BUILDTOOL_DEPENDS}"
-DEPENDS += "pkgconfig-native"
+DEPENDS += "pkgconfig-native pkgconfig gstreamer1.0 glib-2.0"
+
+do_configure:prepend() {
+    export PKG_CONFIG_SYSROOT_DIR="${RECIPE_SYSROOT}"
+    export PKG_CONFIG_PATH="${RECIPE_SYSROOT}${libdir}/pkgconfig:${RECIPE_SYSROOT}${datadir}/pkgconfig"
+    export PKG_CONFIG_LIBDIR="${RECIPE_SYSROOT}${libdir}/pkgconfig:${RECIPE_SYSROOT}${datadir}/pkgconfig"
+}
+
+EXTRA_OECMAKE:append = " -DCMAKE_SYSROOT=${RECIPE_SYSROOT} -DPKG_CONFIG_SYSROOT_DIR=${RECIPE_SYSROOT}"
+
+# EXTRA_OECMAKE += "-DSYSROOT_LIBDIR=${STAGING_LIBDIR}"
+# EXTRA_OECMAKE += "-DGST_PLUGINS_QTI_OSS_INSTALL_LIBDIR=${libdir}"
 
 GST_PLUGIN_INSTALL_DIR ?= "${libdir}/gstreamer-1.0"
-
-EXTRA_OECMAKE += "-DSYSROOT_LIBDIR=${STAGING_LIBDIR}"
-EXTRA_OECMAKE += "-DGST_PLUGINS_QTI_OSS_INSTALL_LIBDIR=${libdir}"
 
 do_install:append() {
     install -d -m 0755 ${D}${GST_PLUGIN_INSTALL_DIR}


### PR DESCRIPTION
CRs-Fixed: 4462703

MOTIVATION: 
1. Update the commit id align with Mar 5 meta-qcom nightly build. 
2. Fix the ros-gst-bridge do_configure task error.

IMPACT:
1. PR build will use the meta-qcom commit id in Mar 5 for nightly build.
2. Ros-gst-bridge compile and test pass on PR build.