### PR TITLE
ci: add PR template to standardize the PR description

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/default.md
+++ b/.github/PULL_REQUEST_TEMPLATE/default.md
@@ -1,0 +1,10 @@
+CRs-Fixed: CR number(s)
+
+**Motivation:**
+Describe the motivation behind the changes.
+
+**Impact:**
+Describe the impact of the changes.
+
+**Dependent PRs(Optional):**
+Link to any dependent PRs.


### PR DESCRIPTION
CRs-Fixed: 4478955

Motivation: 
- Add PULL_REQUEST_TEMPLATE markdown example file.

Impact: 
- The PR description template will be displayed on the pull request page.