### PR TITLE
fix: remove boost system component for Boost 1.90.0+

### DIFF
--- a/recipes-bbappends/recipe-ros/moveit/moveit-ros-planning-interface/0001-fix-remove-boost-system-component-for-Boost-1.90.0.patch
+++ b/recipes-bbappends/recipe-ros/moveit/moveit-ros-planning-interface/0001-fix-remove-boost-system-component-for-Boost-1.90.0.patch
@@ -1,0 +1,28 @@
+From 452de9d2e3ece224b855ad8eaf3877d668ba4288 Mon Sep 17 00:00:00 2001
+From: Teng Fan <tengf@qti.qualcomm.com>
+Date: Fri, 20 Mar 2026 10:46:47 +0800
+Subject: [PATCH] fix: remove boost system component for Boost 1.90.0+
+
+In Boost 1.90.0+, boost::system is header-only and no longer provides
+a separate library. Remove it from the COMPONENTS list as it's
+automatically included with Boost headers.
+
+Upstream-Status: Pending [specific to QIRP SDK cross-build environment]
+Signed-off-by: Teng Fan <tengf@qti.qualcomm.com>
+
+---
+ ConfigExtras.cmake | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/ConfigExtras.cmake b/ConfigExtras.cmake
+index 63a5f42..05ffe2f 100644
+--- a/ConfigExtras.cmake
++++ b/ConfigExtras.cmake
+@@ -8,4 +8,4 @@ find_package(
+   Boost REQUIRED
+   COMPONENTS date_time filesystem program_options
+              # ${BOOST_PYTHON_COMPONENT}
+-             system thread)
++             thread)
+--
+2.34.1

--- a/recipes-bbappends/recipe-ros/moveit/moveit-ros-planning-interface_%.bbappend
+++ b/recipes-bbappends/recipe-ros/moveit/moveit-ros-planning-interface_%.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
+
+SRC_URI += " \
+    file://0001-fix-remove-boost-system-component-for-Boost-1.90.0.patch \
+"

--- a/recipes/qrb-ros-samples/simulation-sample-pick-and-place_1.0.1.bb
+++ b/recipes/qrb-ros-samples/simulation-sample-pick-and-place_1.0.1.bb
@@ -46,21 +46,6 @@ ROS_EXEC_DEPENDS = "${ROS_BUILD_DEPENDS}"
 DEPENDS = "${ROS_BUILD_DEPENDS} ${ROS_BUILDTOOL_DEPENDS} pkgconfig-native pkgconfig"
 RDEPENDS:${PN} += "${ROS_EXEC_DEPENDS}"
 
-do_configure:prepend() {
-    bbnote "== RECIPE_SYSROOT: ${RECIPE_SYSROOT} ==="
-    bbnote "== CMAKE_SYSROOT: ${CMAKE_SYSROOT} ==="
-
-    cfg="${RECIPE_SYSROOT}/usr/ros/${ROS_DISTRO}/share/moveit_ros_planning_interface/cmake/ConfigExtras.cmake"
-    if [ -f "$cfg" ]; then
-        sed -i 's/[[:space:]]system[[:space:]]/ /g; s/[[:space:]]system)//g; s/[[:space:]]system$/ /g' "$cfg"
-    fi
-
-    # export PKG_CONFIG_SYSROOT_DIR="${RECIPE_SYSROOT}"
-    # export PKG_CONFIG_LIBDIR="${RECIPE_SYSROOT}${libdir}/pkgconfig:${RECIPE_SYSROOT}${datadir}/pkgconfig"
-    # unset PKG_CONFIG_PATH
-
-}
-
 FILES:${PN} += " \
     ${libdir}/${ROS_CN}/* \
     ${datadir}/${ROS_CN}/* \


### PR DESCRIPTION
CRs-Fixed: 4472997

Motivation:
In Boost 1.90.0+, boost::system is header-only and no longer provides a separate library. 
Remove it from the COMPONENTS list as it's automatically included with Boost headers.

Impact:
Boost system component will be deprecated from moveit_ros_planning_interface export cmake file.