### PR TITLE
feat: organize sample source code in the qirp sdk.

### DIFF
--- a/classes/psdk-image.bbclass
+++ b/classes/psdk-image.bbclass
@@ -69,104 +69,37 @@ process_qir_samples() {
     
     jq -c '.samples[]' $CONFIG_FILE | while read line; do
         name=$(echo $line | jq -r '.name')
-        oss_channel=$(echo $line | jq -r '.oss_channel')
-        from_uri=$(echo $line | jq -r '.from_uri')
-        branch=$(echo $line | jq -r '.branch')
-        src_rev=$(echo $line | jq -r '.src_rev')
-        individual_prj=$(echo $line | jq -r '.individual_prj')
-        from_local="$(echo $line | jq -r '.from_local')"
-        to="${QIRP_SSTATE_IN_DIR}/${SDK_PN}/$(echo $line | jq -r '.to')"
+        to_dir="${QIRP_SSTATE_IN_DIR}/${SDK_PN}/$(echo $line | jq -r '.to')"
 
         bbnote "  Processing sample: $name"
-        bbnote "  oss_channel: $oss_channel, OSS_CHANNEL_FLAG: ${OSS_CHANNEL_FLAG}"
-        bbnote "  from_uri: $from_uri"
-        bbnote "  src_rev: $src_rev"
-        bbnote "  Target path (to): $to"
-
-        # Use test command instead of [[ ]]
-        if [ "$oss_channel" = "false" ] && [ "$oss_channel" != "${OSS_CHANNEL_FLAG}" ]; then
-            bbwarn "Skipping $name cause of channel mismatch ..."
-            continue
+        bbnote "  Target directory: $to_dir"
+        
+        # mkdir ${to_dir}
+        install -d "${to_dir}"
+        
+        # Copy ${source_dir} to ${to_dir}
+        source_dir="${DEPLOY_DIR}/sample_source_code/${name}"
+        if [ -d "${source_dir}" ]; then
+            bbnote "  Copying entire directory ${source_dir} to ${to_dir}/"
+            cp -rf "${source_dir}" "${to_dir}/"
+        else
+            bbwarn "  Source directory ${source_dir} does not exist, skipping sample: $name"
         fi
 
-        if [ -n "$from_uri" ] && [ "$from_uri" != "null" ]; then
-            # Special handling for qrb_ros_samples
-            if echo "$from_uri" | grep -q "qrb_ros_samples"; then
-                bbnote "Detected qrb_ros_samples repository"
-                if [ -z "${QRB_ROS_SAMPLE_REV}" ]; then
-                    bbwarn "QRB_ROS_SAMPLE_REV is not set, using original src_rev: $src_rev"
-                else
-                    src_rev="${QRB_ROS_SAMPLE_REV}"
-                    bbnote "Using QRB_ROS_SAMPLE_REV: $src_rev"
-                fi
-            fi
-            
-            if [ "$individual_prj" = "false" ]; then
-                # For non-individual projects, clone to temp directory and copy specific subdirectory
-                bbnote "$name: cloning to temp directory (individual_prj=false)"
-                tempdir=$(mktemp -p ${TOPDIR} -d)
-                
-                # Clone to temp directory
-                if git clone -b $branch $from_uri $tempdir; then
-                    cd $tempdir/
-                    if git checkout $src_rev; then
-                        cd -
-                        # Ensure target directory exists
-                        install -d $to
-                        # Find and copy the specific subdirectory
-                        if find $tempdir/ -name "$name" -type d -prune -exec cp -r {} $to \;; then
-                            bbnote "Successfully copied $name from $tempdir to $to"
-                        else
-                            bbwarn "Could not find $name in cloned repository at $tempdir"
-                        fi
-                    else
-                        bbwarn "Failed to checkout $src_rev for $name"
-                    fi
-                else
-                    bbwarn "Failed to clone $from_uri for $name"
-                fi
-                # Clean up temp directory
-                rm -rf $tempdir
-            else
-                # For individual projects, create target directory and clone directly
-                bbnote "$name: cloning as individual project (individual_prj=true)"
-                install -d $to
-                if git clone -b $branch $from_uri $to$name; then
-                    cd $to$name
-                    if git checkout $src_rev; then
-                        cd -
-                        bbnote "Successfully cloned and checked out $name"
-                    else
-                        bbwarn "Failed to checkout $src_rev for $name"
-                    fi
-                else
-                    bbwarn "Failed to clone $from_uri for $name"
-                fi
-            fi
-            continue
-        fi
-
-        # Handle local source copying
-        if [ -d "${TOPDIR}/$from_local$name" ]; then
-            bbnote "Copy sample source from ${TOPDIR}/$from_local$name to $to"
-            install -d $to
-            cp -r ${TOPDIR}/$from_local$name $to
-        fi
     done
 
     # Process scripts from config file
     jq -c '.scripts[]' $CONFIG_FILE | while read line; do
-        name=$(echo $line | jq -r '.name')
         from_local="${ROBIOTICS_LAYER_DIR}/recipes-sdk/files/$(echo $line | jq -r '.from_local')"
         to="${QIRP_SSTATE_IN_DIR}/${SDK_PN}/$(echo $line | jq -r '.to')"
 
-        if [ -d "$from_local$name" ]; then
+        if [ -d "$from_local" ]; then
             # Ensure target directory exists
             install -d $(dirname "$to")
-            cp -r "$from_local$name" "$to"
-            bbnote "Copy sample source from $from_local$name to $to"
+            cp -r "$from_local" "$to"
+            bbnote "Copy sample source from $from_local to $to"
         else
-            bbwarn "Source directory $from_local$name does not exist, skipping"
+            bbwarn "Source directory $from_local does not exist, skipping"
         fi
     done
 

--- a/classes/robotics-package.bbclass
+++ b/classes/robotics-package.bbclass
@@ -39,6 +39,33 @@ do_move_opt() {
 
 do_install[postfuncs] += "do_move_opt"
 
+# Function: do_copy_source_to_deploy
+# Copy all files from S directory to ${DEPLOY_DIR}/sample_source_code/${BPN}/
+# This happens after do_patch and before do_package to capture patched source code.
+do_copy_source_to_deploy() {
+    # Create destination directory: ${DEPLOY_DIR}/sample_source_code/${BPN}/
+    dest_dir="${DEPLOY_DIR}/sample_source_code/${BPN}"
+    
+    # Remove directory if it exists, then recreate it
+    if [ -d "${dest_dir}" ]; then
+        bbnote "Removing existing directory: ${dest_dir}"
+        rm -rf "${dest_dir}"
+    fi
+    
+    install -d "${dest_dir}"
+    
+    # Copy all files from S directory
+    if [ -d "${S}" ]; then
+        bbnote "Copying source files from ${S} to ${dest_dir}"
+        cp -r "${S}/"* "${dest_dir}/" 2>/dev/null || true
+    else
+        bbwarn "Source directory ${S} does not exist, skipping source copy"
+    fi
+}
+
+# Add task: copy source to deploy directory after patching
+addtask do_copy_source_to_deploy after do_patch before do_configure
+
 AUTO_LIBNAME_PKGS = ""
 
 FILES:${PN} += " \

--- a/recipes-sdk/files/content_config.json
+++ b/recipes-sdk/files/content_config.json
@@ -1,76 +1,54 @@
 {
     "samples": [
         {
-            "name": "qrb_ros_imu",
-            "oss_channel": "true",
-            "individual_prj": "true",
-            "from_uri":"https://github.com/qualcomm-qrb-ros/qrb_ros_imu.git",
-            "branch":"main",
-            "src_rev":"e567bc29ca2d96737167a7c3720c3cd86b706c6a",
+            "name": "qrb-ros-system-monitor",
             "to": "qirp-samples/platform/"
         },
         {
-            "name": "qrb_ros_system_monitor",
-            "oss_channel": "true",
-            "from_uri":"https://github.com/qualcomm-qrb-ros/qrb_ros_system_monitor.git",
-            "branch":"main",
-            "src_rev":"8680cbe57fc62a68f3e2d98f4e9b726bb8bce726",
-            "individual_prj": "ture",
+            "name": "ocr-service",
             "to": "qirp-samples/platform/"
         },
         {
-            "name": "qrb_ros_battery",
-            "oss_channel": "true",
-            "from_uri":"https://github.com/qualcomm-qrb-ros/qrb_ros_battery.git",
-            "branch":"main",
-            "src_rev":"37bf3ff7fe37975c3a8d839340e9a473544d5db4",
-            "individual_prj": "true",
+            "name": "qrb-ros-colorspace-convert",
             "to": "qirp-samples/platform/"
         },
         {
-            "name": "ocr_service",
-            "oss_channel": "true",
-            "individual_prj": "true",
-            "from_uri": "https://git.codelinaro.org/clo/le/qirp-oss.git",
-            "branch":"robotics-sdk.qclinux.1.0.r1-rel",
-            "src_rev":"1a5a68c7208bcb64b9c9998426600c6da6ce068d",
-            "from_local": "robotics/qirp-oss/samples/ai_nodes/",
+            "name": "simulation-sample-pick-and-place",
+            "to": "qirp-samples/robotics"
+        },
+        {
+            "name": "simulation-sample-amr-simple-motion",
+            "to": "qirp-samples/robotics"
+        },
+        {
+            "name": "sample-hrnet-pose-estimation",
+            "to": "qirp-samples/ai_vision/"
+        },
+        {
+            "name": "sample-face-detection",
+            "to": "qirp-samples/ai_vision/"
+        },
+        {
+            "name": "ros-gst-bridge",
             "to": "qirp-samples/platform/"
         },
         {
-            "name": "qrb_ros_camera",
-            "oss_channel": "true",
-            "from_uri":"https://github.com/qualcomm-qrb-ros/qrb_ros_camera.git",
-            "branch":"main",
-            "src_rev":"8f9598e0da29fb02af91f841a25a2cc7c1018601",
-            "individual_prj": "true",
+            "name": "qrb-ros-benchmark",
             "to": "qirp-samples/platform/"
         },
         {
-            "name": "ai_vision",
-            "oss_channel": "true",
-            "from_uri":"https://github.com/qualcomm-qrb-ros/qrb_ros_samples.git",
-            "branch":"jazzy-rel",
-            "src_rev":"${QRB_ROS_SAMPLE_REV}",
-            "individual_prj": "false",
-            "to": "qirp-samples/"
+            "name": "rplidar-ros2",
+            "to": "qirp-samples/platform/"
         },
         {
-            "name": "robotics",
-            "oss_channel": "true",
-            "from_uri":"https://github.com/qualcomm-qrb-ros/qrb_ros_samples.git",
-            "branch":"jazzy-rel",
-            "src_rev":"${QRB_ROS_SAMPLE_REV}",
-            "individual_prj": "false",
-            "to": "qirp-samples/"
+            "name": "qrb-ros-camera",
+            "to": "qirp-samples/platform/"
         }
       ],
       "scripts": [
         {
-            "name": "scripts",
-            "oss_channel": "true",
-            "from_local":"qrb_ros_samples_scripts/qrb_ros_system_monitor/",
-            "to": "qirp-samples/platform/qrb_ros_system_monitor/"
-            }
+            "from_local":"qrb_ros_samples_scripts/qrb_ros_system_monitor/scripts",
+            "to": "qirp-samples/platform/qrb-ros-system-monitor/"
+        }
       ]
 }


### PR DESCRIPTION
CRs-Fixed: 4480919

**Motivation:**
Since the source code used in the qirp SDK needs to be patched, but the current qirp SDK directory only uses git to download from the remote repository, it is impossible to perform the patching operation.
Therefore, it's need to modify the packaging logic of the qirp SDK. 
**Impact:**
The qirp sdk put the source code of patched to qirp sdk. And if you need to add the source code to the qirp SDK, you need to add the "sample" name to the "content_config.json" file.