### PR TITLE
feat: enable cartographer ROS package

### DIFF
--- a/recipes-products/packagegroups/packagegroup-robotics-opensource.bb
+++ b/recipes-products/packagegroups/packagegroup-robotics-opensource.bb
@@ -50,6 +50,7 @@ EXTERNAL_OPENSOURCE = " \
     rplidar-ros2 \
     orbbec-camera \
     cartographer \
+    cartographer-ros \
 "
 
 ROS_GST_BRIDGE = " \


### PR DESCRIPTION
CRs-Fixed: 4469812

Motivation
Enable cartographer ROS Package. Add cartographer-ros into qcom-robotics-sdk

Impact
After this change, the cartographer ROS Package can be enabled.

