### PR TITLE
feat: add follow path service recipes

### DIFF
--- a/recipes-products/packagegroups/packagegroup-robotics-opensource.bb
+++ b/recipes-products/packagegroups/packagegroup-robotics-opensource.bb
@@ -38,7 +38,9 @@ QUALCOMM_QRB_ROS = " \
     qrb-ros-slam-msgs \
     qrb-ros-amr-msgs \
     qrb-ros-navigation-msgs \
+    qrb-amr-manager \
     qrb-follow-path-manager \
+    qrb-ros-amr \
     qrb-ros-follow-path \
 "
 

--- a/recipes-products/packagegroups/packagegroup-robotics-opensource.bb
+++ b/recipes-products/packagegroups/packagegroup-robotics-opensource.bb
@@ -35,6 +35,11 @@ QUALCOMM_QRB_ROS = " \
     qrb-ros-robot-base-urdf \
     qrb-ros-robot-base \
     qrb-ros-benchmark \
+    qrb-ros-slam-msgs \
+    qrb-ros-amr-msgs \
+    qrb-ros-navigation-msgs \
+    qrb-follow-path-manager \
+    qrb-ros-follow-path \
 "
 
 # If it is qrb ros sample, Please place all of them under this variable.

--- a/recipes/qrb-ros-amr-service/qrb-amr-manager_1.0.4.bb
+++ b/recipes/qrb-ros-amr-service/qrb-amr-manager_1.0.4.bb
@@ -1,0 +1,46 @@
+inherit ros_distro_${ROS_DISTRO}
+inherit ros_component
+inherit ros_insane_dev_so
+
+DESCRIPTION      = "QRB AMR Library"
+AUTHOR           = "Xiaowei Zhang <xiaowz@qti.qualcomm.com>"
+ROS_AUTHOR       = "Xiaowei Zhang"
+SECTION          = "devel"
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://../LICENSE;md5=ad92c59628114dbd93a5031a4e684080"
+
+ROS_CN = "qrb_amr_manager"
+ROS_BPN = "qrb_amr_manager"
+
+ROS_BUILD_DEPENDS = " \
+"
+
+ROS_BUILDTOOL_DEPENDS = " \
+    ament-cmake-auto-native \
+"
+
+ROS_EXEC_DEPENDS = " \
+"
+
+ROS_EXPORT_DEPENDS = " \
+"
+
+ROS_BUILDTOOL_EXPORT_DEPENDS = ""
+
+NON_ROS_EXEC_DEPENDS = " \
+"
+
+DEPENDS = "${ROS_BUILD_DEPENDS} ${ROS_BUILDTOOL_DEPENDS}"
+DEPENDS += "${ROS_EXPORT_DEPENDS} ${ROS_BUILDTOOL_EXPORT_DEPENDS}"
+
+RDEPENDS:${PN} += "${ROS_EXEC_DEPENDS} ${NON_ROS_EXEC_DEPENDS}"
+
+SRC_URI = "git://github.com/qualcomm-qrb-ros/qrb_ros_amr_service.git;protocol=https;branch=stable/1.0.4"
+SRCREV = "5f7b966144252b604c3fb3f81472ab138b13c4a5"
+S = "${UNPACKDIR}/${BP}/qrb_amr_manager"
+
+ROS_BUILD_TYPE = "ament_cmake"
+
+inherit ros_${ROS_BUILD_TYPE}
+
+inherit robotics-package

--- a/recipes/qrb-ros-amr-service/qrb-ros-amr_1.0.4.bb
+++ b/recipes/qrb-ros-amr-service/qrb-ros-amr_1.0.4.bb
@@ -1,0 +1,101 @@
+inherit ros_distro_${ROS_DISTRO}
+inherit ros_component
+
+DESCRIPTION      = "QRB AMR ROS node"
+AUTHOR           = "Xiaowei Zhang <xiaowz@qti.qualcomm.com>"
+ROS_AUTHOR       = "Xiaowei Zhang"
+SECTION          = "devel"
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://../LICENSE;md5=ad92c59628114dbd93a5031a4e684080"
+
+ROS_CN = "qrb_ros_amr"
+ROS_BPN = "qrb_ros_amr"
+
+ROS_BUILD_DEPENDS = " \
+    rclcpp \
+    std-msgs \
+    rclcpp-components \
+    nav-msgs \
+    nav2-msgs \
+    nav-2d-msgs \
+    geometry-msgs \
+    rclcpp-action \
+    tf2 \
+    tf2-ros \
+    tf2-geometry-msgs \
+    sensor-msgs \
+    jsoncpp \
+    qrb-ros-amr-msgs \
+    qrb-ros-navigation-msgs \
+    qrb-amr-manager \
+    qrb-ros-robot-base-msgs \
+    qrb-ros-slam-msgs \
+"
+
+ROS_BUILDTOOL_DEPENDS = " \
+    ament-cmake-auto-native \
+"
+
+ROS_EXEC_DEPENDS = " \
+    rclcpp \
+    std-msgs \
+    rclcpp-components \
+    nav-msgs \
+    nav2-msgs \
+    nav-2d-msgs \
+    geometry-msgs \
+    rclcpp-action \
+    tf2 \
+    tf2-ros \
+    tf2-geometry-msgs \
+    sensor-msgs \
+"
+
+ROS_EXPORT_DEPENDS = " \
+    rclcpp \
+    std-msgs \
+    rclcpp-components \
+    nav-msgs \
+    nav2-msgs \
+    nav-2d-msgs \
+    geometry-msgs \
+    rclcpp-action \
+    tf2 \
+    tf2-ros \
+    tf2-geometry-msgs \
+    sensor-msgs \
+"
+
+NON_ROS_EXEC_DEPENDS = " \
+    jsoncpp \
+    qrb-ros-amr-msgs \
+    qrb-ros-navigation-msgs \
+    qrb-amr-manager \
+    qrb-ros-robot-base-msgs \
+    qrb-ros-slam-msgs \
+"
+
+ROS_BUILDTOOL_EXPORT_DEPENDS = ""
+
+DEPENDS = "${ROS_BUILD_DEPENDS} ${ROS_BUILDTOOL_DEPENDS}"
+DEPENDS += "${ROS_EXPORT_DEPENDS} ${ROS_BUILDTOOL_EXPORT_DEPENDS}"
+
+
+do_install:append() {
+    rm -rf ${D}/usr/include/*
+    install -d ${D}/usr/include/qrb_ros_amr/
+    cp -r ${S}/include/*  ${D}/usr/include/qrb_ros_amr/
+}
+
+
+RDEPENDS:${PN} += "${ROS_EXEC_DEPENDS} ${NON_ROS_EXEC_DEPENDS}"
+
+SRC_URI = "git://github.com/qualcomm-qrb-ros/qrb_ros_amr_service.git;protocol=https;branch=stable/1.0.4"
+SRCREV = "5f7b966144252b604c3fb3f81472ab138b13c4a5"
+S         =  "${UNPACKDIR}/${BP}/qrb_ros_amr/"
+
+ROS_BUILD_TYPE = "ament_cmake"
+
+inherit ros_${ROS_BUILD_TYPE}
+
+inherit robotics-package

--- a/recipes/qrb-ros-follow-path-service/qrb-follow-path-manager_1.0.4.bb
+++ b/recipes/qrb-ros-follow-path-service/qrb-follow-path-manager_1.0.4.bb
@@ -1,0 +1,52 @@
+inherit ros_distro_${ROS_DISTRO}
+inherit ros_component
+inherit ros_insane_dev_so
+
+DESCRIPTION = "QRB Follow Path Library"
+AUTHOR           = "Xiaowei Zhang <xiaowz@qti.qualcomm.com>"
+ROS_AUTHOR       = "Xiaowei Zhang"
+SECTION          = "devel"
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://../LICENSE;md5=86fcc2294062130b497ba0ffff9f82fc"
+
+ROS_CN = "qrb_follow_path_manager"
+ROS_BPN = "qrb_follow_path_manager"
+
+ROS_BUILD_DEPENDS = " \
+    libeigen \
+    libtinyxml2 \
+"
+
+ROS_BUILDTOOL_DEPENDS = " \
+    ament-cmake-auto-native \
+"
+
+ROS_EXEC_DEPENDS = " \
+    libeigen \
+    libtinyxml2 \
+"
+
+ROS_EXPORT_DEPENDS = " \
+    libeigen \
+    libtinyxml2 \
+"
+
+ROS_BUILDTOOL_EXPORT_DEPENDS = ""
+
+NON_ROS_EXEC_DEPENDS = " \
+"
+
+DEPENDS = "${ROS_BUILD_DEPENDS} ${ROS_BUILDTOOL_DEPENDS}"
+DEPENDS += "${ROS_EXPORT_DEPENDS} ${ROS_BUILDTOOL_EXPORT_DEPENDS}"
+
+RDEPENDS:${PN} += "${ROS_EXEC_DEPENDS} ${NON_ROS_EXEC_DEPENDS}"
+
+SRC_URI = "git://github.com/qualcomm-qrb-ros/qrb_ros_follow_path_service.git;protocol=https;branch=stable/1.0.4"
+SRCREV = "f62e9f9a18a330240a4e2e5c9776f75861c9473b"
+S = "${UNPACKDIR}/${BP}/qrb_follow_path_manager"
+
+ROS_BUILD_TYPE = "ament_cmake"
+
+inherit ros_${ROS_BUILD_TYPE}
+
+inherit robotics-package

--- a/recipes/qrb-ros-follow-path-service/qrb-ros-amr-msgs_0.2.0.bb
+++ b/recipes/qrb-ros-follow-path-service/qrb-ros-amr-msgs_0.2.0.bb
@@ -1,0 +1,62 @@
+inherit ros_distro_${ROS_DISTRO}
+inherit ros_component
+
+DESCRIPTION = "QRB AMR ROS Messages"
+AUTHOR           = "Xiaowei Zhang <xiaowz@qti.qualcomm.com>"
+ROS_AUTHOR       = "Xiaowei Zhang"
+SECTION          = "devel"
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://../LICENSE;md5=86fcc2294062130b497ba0ffff9f82fc"
+
+ROS_CN = "qrb_ros_amr_msgs"
+ROS_BPN = "qrb_ros_amr_msgs"
+
+ROS_BUILD_DEPENDS = " \
+    rclcpp \
+    std-msgs \
+    nav-msgs \
+    rclcpp-components \
+    geometry-msgs \
+    action-msgs \
+    rosidl-default-generators-native \
+"
+
+ROS_BUILDTOOL_DEPENDS = " \
+    ament-cmake-auto-native \
+"
+
+ROS_EXEC_DEPENDS = " \
+    rclcpp \
+    std-msgs \
+    nav-msgs \
+    rclcpp-components \
+    geometry-msgs \
+    action-msgs \
+"
+
+ROS_EXPORT_DEPENDS = " \
+    rclcpp \
+    std-msgs \
+    nav-msgs \
+    rclcpp-components \
+    geometry-msgs \
+    action-msgs \
+    rosidl-default-generators-native \
+"
+
+ROS_BUILDTOOL_EXPORT_DEPENDS = ""
+
+DEPENDS = "${ROS_BUILD_DEPENDS} ${ROS_BUILDTOOL_DEPENDS}"
+DEPENDS += "${ROS_EXPORT_DEPENDS} ${ROS_BUILDTOOL_EXPORT_DEPENDS}"
+
+RDEPENDS:${PN} += "${ROS_EXEC_DEPENDS}"
+
+SRC_URI = "git://github.com/qualcomm-qrb-ros/qrb_ros_interfaces.git;protocol=https;branch=stable/0.2.0"
+SRCREV = "58afc211200aee777d16ce9b9e916f645de44190"
+S = "${UNPACKDIR}/${BP}/qrb_ros_amr_msgs"
+
+ROS_BUILD_TYPE = "ament_cmake"
+
+inherit ros_${ROS_BUILD_TYPE}
+
+inherit robotics-package

--- a/recipes/qrb-ros-follow-path-service/qrb-ros-follow-path_1.0.4.bb
+++ b/recipes/qrb-ros-follow-path-service/qrb-ros-follow-path_1.0.4.bb
@@ -1,0 +1,92 @@
+inherit ros_distro_${ROS_DISTRO}
+inherit ros_component
+
+DESCRIPTION = "QRB Follow Path ROS node"
+AUTHOR           = "Xiaowei Zhang <xiaowz@qti.qualcomm.com>"
+ROS_AUTHOR       = "Xiaowei Zhang"
+SECTION          = "devel"
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://../LICENSE;md5=86fcc2294062130b497ba0ffff9f82fc"
+
+ROS_CN = "qrb_ros_follow_path"
+ROS_BPN = "qrb_ros_follow_path"
+
+ROS_BUILD_DEPENDS = " \
+    rclcpp \
+    std-msgs \
+    rclcpp-components \
+    nav-msgs \
+    nav2-msgs \
+    sensor-msgs \
+    geometry-msgs \
+    rclcpp-action \
+    tf2 \
+    nav-2d-msgs \
+    tf2-ros \
+    tf2-geometry-msgs \
+    rclcpp-lifecycle \
+    qrb-ros-amr-msgs \
+    qrb-ros-navigation-msgs \
+    qrb-follow-path-manager \
+    qrb-ros-robot-base-msgs \
+"
+
+ROS_BUILDTOOL_DEPENDS = " \
+    ament-cmake-auto-native \
+"
+
+ROS_EXEC_DEPENDS = " \
+    rclcpp \
+    std-msgs \
+    rclcpp-components \
+    nav-msgs \
+    nav2-msgs \
+    sensor-msgs \
+    geometry-msgs \
+    rclcpp-action \
+    tf2 \
+    nav-2d-msgs \
+    tf2-ros \
+    tf2-geometry-msgs \
+    rclcpp-lifecycle \
+"
+
+ROS_EXPORT_DEPENDS = " \
+    rclcpp \
+    std-msgs \
+    rclcpp-components \
+    nav-msgs \
+    nav2-msgs \
+    sensor-msgs \
+    geometry-msgs \
+    rclcpp-action \
+    tf2 \
+    nav-2d-msgs \
+    tf2-ros \
+    tf2-geometry-msgs \
+    rclcpp-lifecycle \
+"
+
+NON_ROS_EXEC_DEPENDS = " \
+    qrb-ros-amr-msgs \
+    qrb-ros-navigation-msgs \
+    qrb-follow-path-manager \
+    qrb-ros-robot-base-msgs \
+"
+
+ROS_BUILDTOOL_EXPORT_DEPENDS = ""
+
+DEPENDS = "${ROS_BUILD_DEPENDS} ${ROS_BUILDTOOL_DEPENDS}"
+DEPENDS += "${ROS_EXPORT_DEPENDS} ${ROS_BUILDTOOL_EXPORT_DEPENDS}"
+
+RDEPENDS:${PN} += "${ROS_EXEC_DEPENDS} ${NON_ROS_EXEC_DEPENDS}"
+
+SRC_URI = "git://github.com/qualcomm-qrb-ros/qrb_ros_follow_path_service.git;protocol=https;branch=stable/1.0.4"
+SRCREV = "f62e9f9a18a330240a4e2e5c9776f75861c9473b"
+S         =  "${UNPACKDIR}/${BP}/qrb_ros_follow_path/"
+
+ROS_BUILD_TYPE = "ament_cmake"
+
+inherit ros_${ROS_BUILD_TYPE}
+
+inherit robotics-package

--- a/recipes/qrb-ros-follow-path-service/qrb-ros-navigation-msgs_0.2.0.bb
+++ b/recipes/qrb-ros-follow-path-service/qrb-ros-navigation-msgs_0.2.0.bb
@@ -1,0 +1,62 @@
+inherit ros_distro_${ROS_DISTRO}
+inherit ros_component
+
+DESCRIPTION = "QRB Navigation ROS Messages"
+AUTHOR           = "Xiaowei Zhang <xiaowz@qti.qualcomm.com>"
+ROS_AUTHOR       = "Xiaowei Zhang"
+SECTION          = "devel"
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://../LICENSE;md5=86fcc2294062130b497ba0ffff9f82fc"
+
+ROS_CN = "qrb_ros_navigation_msgs"
+ROS_BPN = "qrb_ros_navigation_msgs"
+
+ROS_BUILD_DEPENDS = " \
+    rclcpp \
+    std-msgs \
+    nav-msgs \
+    rclcpp-components \
+    geometry-msgs \
+    action-msgs \
+    rosidl-default-generators-native \
+"
+
+ROS_BUILDTOOL_DEPENDS = " \
+    ament-cmake-auto-native \
+"
+
+ROS_EXEC_DEPENDS = " \
+    rclcpp \
+    std-msgs \
+    nav-msgs \
+    rclcpp-components \
+    geometry-msgs \
+    action-msgs \
+"
+
+ROS_EXPORT_DEPENDS = " \
+    rclcpp \
+    std-msgs \
+    nav-msgs \
+    rclcpp-components \
+    geometry-msgs \
+    action-msgs \
+    rosidl-default-generators-native \
+"
+
+ROS_BUILDTOOL_EXPORT_DEPENDS = ""
+
+DEPENDS = "${ROS_BUILD_DEPENDS} ${ROS_BUILDTOOL_DEPENDS}"
+DEPENDS += "${ROS_EXPORT_DEPENDS} ${ROS_BUILDTOOL_EXPORT_DEPENDS}"
+
+RDEPENDS:${PN} += "${ROS_EXEC_DEPENDS}"
+
+SRC_URI = "git://github.com/qualcomm-qrb-ros/qrb_ros_interfaces.git;protocol=https;branch=stable/0.2.0"
+SRCREV = "58afc211200aee777d16ce9b9e916f645de44190"
+S = "${UNPACKDIR}/${BP}/qrb_ros_navigation_msgs"
+
+ROS_BUILD_TYPE = "ament_cmake"
+
+inherit ros_${ROS_BUILD_TYPE}
+
+inherit robotics-package


### PR DESCRIPTION
CRs-Fixed: 4478532

Motivation:
This PR adds the follow path service & amr service and its related recipes to the build system. The goal is to allow the qrb-ros-follow-path, qrb-follow-path-manager, qrb-ros-amr and qrb-amr-manager to be built independently with proper build system support, making its integration more modular and aligned with existing build workflows.

Impact:
After this change, the follow-path-service and amr-service can be enabled and compiled as a standalone component through the build system.