### PR TITLE
feat: add qrb-ros-nn-inference recipe and enable it on packagegroup

### DIFF
--- a/recipes-products/packagegroups/packagegroup-robotics-opensource.bb
+++ b/recipes-products/packagegroups/packagegroup-robotics-opensource.bb
@@ -42,6 +42,7 @@ QUALCOMM_QRB_ROS = " \
     qrb-follow-path-manager \
     qrb-ros-amr \
     qrb-ros-follow-path \
+    qrb-ros-nn-inference \
 "
 
 # If it is qrb ros sample, Please place all of them under this variable.

--- a/recipes/qrb-ros-nn-inference/files/0001-feat-replace-tflite-Cpp-API-to-C-API.patch
+++ b/recipes/qrb-ros-nn-inference/files/0001-feat-replace-tflite-Cpp-API-to-C-API.patch
@@ -1,0 +1,229 @@
+From 5893c09e67a5c604d8ed0fd938f45c9d4d7407ba Mon Sep 17 00:00:00 2001
+From: Na Song <nasong@qti.qualcomm.com>
+Date: Wed, 1 Apr 2026 16:53:48 +0800
+Subject: [PATCH] feat: replace tflite Cpp API to C API
+
+Upstream-Status: Pending
+
+Signed-off-by: Na Song <nasong@qti.qualcomm.com>
+---
+ .../qnn_delegate_inference.hpp                | 10 ++-
+ .../include/qrb_inference.hpp                 |  1 +
+ .../qnn_delegate_inference.cpp                | 90 ++++++++-----------
+ 3 files changed, 43 insertions(+), 58 deletions(-)
+
+diff --git a/qrb_inference_manager/include/qnn_delegate_inference/qnn_delegate_inference.hpp b/qrb_inference_manager/include/qnn_delegate_inference/qnn_delegate_inference.hpp
+index 0382354..de8e485 100644
+--- a/qrb_inference_manager/include/qnn_delegate_inference/qnn_delegate_inference.hpp
++++ b/qrb_inference_manager/include/qnn_delegate_inference/qnn_delegate_inference.hpp
+@@ -4,8 +4,9 @@
+ #ifndef QRB_INFERENCE_MANAGER_QNN_DELEGATE_INFERENCE_HPP_
+ #define QRB_INFERENCE_MANAGER_QNN_DELEGATE_INFERENCE_HPP_
+
+-#include <tensorflow/lite/interpreter.h>
+-#include <tensorflow/lite/model.h>
++#include <tensorflow/lite/c/c_api.h>
++#include <tensorflow/lite/c/c_api_experimental.h>
++#include <tensorflow/lite/c/common.h>
+
+ #include <string>
+
+@@ -29,8 +30,9 @@ private:
+   const std::string backend_option_ = "";
+   std::vector<OutputTensor> output_tensor_;
+
+-  std::unique_ptr<tflite::FlatBufferModel> model_{ nullptr };
+-  std::unique_ptr<tflite::Interpreter> interpreter_;
++  TfLiteModel * model_ = nullptr;
++  TfLiteInterpreterOptions * options_ = nullptr;
++  TfLiteInterpreter * interpreter_ = nullptr;
+   TfLiteDelegate * delegate_ = nullptr;
+
+   StatusCode register_qnn_delegate();
+diff --git a/qrb_inference_manager/include/qrb_inference.hpp b/qrb_inference_manager/include/qrb_inference.hpp
+index 031d982..46f4809 100644
+--- a/qrb_inference_manager/include/qrb_inference.hpp
++++ b/qrb_inference_manager/include/qrb_inference.hpp
+@@ -8,6 +8,7 @@
+ #include <memory>
+ #include <string>
+ #include <vector>
++#include <cstdint>
+
+ namespace qrb::inference_mgr
+ {
+diff --git a/qrb_inference_manager/src/qnn_delegate_inference/qnn_delegate_inference.cpp b/qrb_inference_manager/src/qnn_delegate_inference/qnn_delegate_inference.cpp
+index 13285ad..8b1b9e7 100644
+--- a/qrb_inference_manager/src/qnn_delegate_inference/qnn_delegate_inference.cpp
++++ b/qrb_inference_manager/src/qnn_delegate_inference/qnn_delegate_inference.cpp
+@@ -1,10 +1,7 @@
+ // Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+ // SPDX-License-Identifier: BSD-3-Clause-Clear
+-
+ #include "qnn_delegate_inference/qnn_delegate_inference.hpp"
+
+-#include <tensorflow/lite/kernels/register.h>
+-
+ #include <cstring>
+
+ #include "TFLiteDelegate/QnnTFLiteDelegate.h"
+@@ -21,6 +18,18 @@ QnnDelegateInference::QnnDelegateInference(const std::string & model_path,
+
+ QnnDelegateInference::~QnnDelegateInference()
+ {
++  if (this->interpreter_ != nullptr) {
++    TfLiteInterpreterDelete(interpreter_);
++  }
++
++  if (this->options_ != nullptr) {
++    TfLiteInterpreterOptionsDelete(options_);
++  }
++
++  if (this->model_ != nullptr) {
++    TfLiteModelDelete(model_);
++  }
++
+   if (this->delegate_ != nullptr) {
+     TfLiteQnnDelegateDelete(this->delegate_);
+   }
+@@ -49,13 +58,7 @@ StatusCode QnnDelegateInference::register_qnn_delegate()
+       QRB_ERROR("Qnn Delegate create fail!");
+       return StatusCode::FAILURE;
+     }
+-
+-    if (TfLiteStatus::kTfLiteOk == this->interpreter_->ModifyGraphWithDelegate(this->delegate_)) {
+-      QRB_INFO("Enable QNN delegate Successfully!");
+-    } else {
+-      QRB_ERROR("Qnn Delegate register fail!");
+-      return StatusCode::FAILURE;
+-    }
++    TfLiteInterpreterOptionsAddDelegate(options_, delegate_);
+   }
+
+   return StatusCode::SUCCESS;
+@@ -63,30 +66,30 @@ StatusCode QnnDelegateInference::register_qnn_delegate()
+
+ StatusCode QnnDelegateInference::inference_init()
+ {
+-  this->model_ = tflite::FlatBufferModel::BuildFromFile((this->model_path_).c_str());
+-  if (this->model_ == nullptr) {
+-    QRB_ERROR("TFLite model load fail!");
++  model_ = TfLiteModelCreateFromFile(model_path_.c_str());
++  if (model_ == nullptr) {
++    QRB_ERROR("TFLite model create fail!");
+     return StatusCode::FAILURE;
+   }
+
+-  tflite::ops::builtin::BuiltinOpResolver resolver;
+-  tflite::InterpreterBuilder(*(this->model_), resolver)(&(this->interpreter_));
+-  if (this->interpreter_ == nullptr) {
+-    QRB_ERROR("TFLite interpreter build fail!");
++  options_ = TfLiteInterpreterOptionsCreate();
++  if (this->register_qnn_delegate() == StatusCode::FAILURE) {
+     return StatusCode::FAILURE;
+   }
+
+-  if (TfLiteStatus::kTfLiteOk != this->interpreter_->AllocateTensors()) {
+-    QRB_ERROR("TFLite input tensor create fail!");
++  TfLiteInterpreterOptionsSetNumThreads(options_, 4);
++  interpreter_ = TfLiteInterpreterCreate(model_, options_);
++  if (interpreter_ == nullptr) {
++    QRB_ERROR("TFLite interpreter create fail!");
+     return StatusCode::FAILURE;
+   }
+
++  TfLiteInterpreterAllocateTensors(interpreter_);
++
+   if (this->register_qnn_delegate() == StatusCode::FAILURE) {
+     return StatusCode::FAILURE;
+   }
+
+-  QRB_INFO("Inference init Successfully!");
+-
+   return StatusCode::SUCCESS;
+ }
+
+@@ -97,25 +100,10 @@ StatusCode QnnDelegateInference::inference_graph_init()
+
+ StatusCode QnnDelegateInference::inference_execute(const std::vector<uint8_t> & input_tensor_data)
+ {
+-  auto tflite_dtype_to_qrb_dtype = [](const TfLiteType & tflite_dtype) -> int32_t {
+-    switch (tflite_dtype) {
+-      case kTfLiteUInt8:
+-        return 0;
+-      case kTfLiteInt8:
+-        return 1;
+-      case kTfLiteFloat32:
+-        return 2;
+-      case kTfLiteFloat64:
+-        return 3;
+-      default:
+-        return -1;
+-    }
+-  };
+-
+-  auto input_tensor = this->interpreter_->tensor(this->interpreter_->inputs()[0]);
++  TfLiteTensor * input_tensor = TfLiteInterpreterGetInputTensor(interpreter_, 0);
+
+-  if (-1 == tflite_dtype_to_qrb_dtype(input_tensor->type)) {
+-    QRB_ERROR("The input data type of model is NOT supported");
++  if (input_tensor->type != kTfLiteFloat32) {
++    QRB_ERROR("The data type of input tensor need to be FLOAT32!");
+     return StatusCode::FAILURE;
+   }
+
+@@ -125,27 +113,23 @@ StatusCode QnnDelegateInference::inference_execute(const std::vector<uint8_t> &
+     return StatusCode::FAILURE;
+   }
+
+-  // input_tensor->data.raw = input_tensor_data.data();
+-  memcpy(input_tensor->data.f, input_tensor_data.data(), input_tensor_data.size());
++  TfLiteTensorCopyFromBuffer(
++      input_tensor, input_tensor_data.data(), input_tensor_data.size() * sizeof(float));
+
+-  if (TfLiteStatus::kTfLiteOk != this->interpreter_->Invoke()) {
++  if (TfLiteStatus::kTfLiteOk != TfLiteInterpreterInvoke(interpreter_)) {
+     QRB_ERROR("TFLite invoke fail!");
+     return StatusCode::FAILURE;
+   }
+
+-  for (size_t i = 0; i < this->interpreter_->outputs().size(); i++) {
+-    auto result_tensor = this->interpreter_->output_tensor(i);
++  for (int32_t i = 0; i < TfLiteInterpreterGetOutputTensorCount(interpreter_); i++) {
++    const TfLiteTensor * result_tensor = TfLiteInterpreterGetOutputTensor(interpreter_, i);
++
+     OutputTensor output_tensor;
+-    output_tensor.data_type = tflite_dtype_to_qrb_dtype(result_tensor->type);
+-    if (output_tensor.data_type == -1) {
+-      QRB_ERROR("The output data type of model is NOT supported");
+-      return StatusCode::FAILURE;
+-    }
+
+     output_tensor.output_tensor_name = result_tensor->name;
++
+     output_tensor.output_tensor_data = std::vector<uint8_t>(result_tensor->bytes);
+-    memcpy(output_tensor.output_tensor_data.data(), result_tensor->data.raw,
+-        result_tensor->bytes);  // reinterpret_cast<uint8_t*>
++    memcpy(output_tensor.output_tensor_data.data(), result_tensor->data.f, result_tensor->bytes);
+
+     for (auto j = 0; j < result_tensor->dims->size; j++) {
+       output_tensor.output_tensor_shape.emplace_back(result_tensor->dims->data[j]);
+@@ -154,8 +138,6 @@ StatusCode QnnDelegateInference::inference_execute(const std::vector<uint8_t> &
+     this->output_tensor_.emplace_back(output_tensor);
+   }
+
+-  QRB_INFO("Inference execute Successfully!");
+-
+   return StatusCode::SUCCESS;
+ }
+
+@@ -164,4 +146,4 @@ const std::vector<OutputTensor> QnnDelegateInference::get_output_tensors()
+   return std::move(this->output_tensor_);
+ }
+
+-}  // namespace qrb::inference_mgr
++}  // namespace qrb::inference_mgr
+\ No newline at end of file
+--
+2.34.1
+

--- a/recipes/qrb-ros-nn-inference/qrb-inference-manager_0.0.0.1.bb
+++ b/recipes/qrb-ros-nn-inference/qrb-inference-manager_0.0.0.1.bb
@@ -1,0 +1,65 @@
+inherit ros_distro_${ROS_DISTRO} pkgconfig
+inherit ros_component robotics-package
+
+DESCRIPTION = "Lib of qrb-ros-nn-inference"
+AUTHOR = "Na Song <nasong@qti.qualcomm.com>"
+ROS_AUTHOR = "Na Song"
+SECTION = "devel"
+LICENSE = "BSD-3-Clause-Clear"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/${LICENSE};md5=7a434440b651f4a472ca93716d01033a"
+
+ROS_CN = "qrb_inference_manager"
+ROS_BPN = "qrb_inference_manager"
+
+BUILD_DEPENDS = " \
+    qairt-sdk \
+    tensorflow-lite \
+"
+
+ROS_BUILD_DEPENDS = " \
+"
+
+ROS_BUILDTOOL_DEPENDS = " \
+    ament-cmake-auto-native \
+"
+
+ROS_EXPORT_DEPENDS = " \
+"
+
+ROS_BUILDTOOL_EXPORT_DEPENDS = ""
+
+ROS_EXEC_DEPENDS = " \
+    rclcpp \
+    qairt-sdk \
+    tensorflow-lite \
+"
+
+ROS_TEST_DEPENDS = " \
+    ament-lint-auto \
+    ament-lint-common \
+"
+
+DEPENDS = "${BUILD_DEPENDS} ${ROS_BUILD_DEPENDS} ${ROS_BUILDTOOL_DEPENDS}"
+DEPENDS += "${ROS_EXPORT_DEPENDS} ${ROS_BUILDTOOL_EXPORT_DEPENDS} ${ROS_TEST_DEPENDS}"
+
+RDEPENDS:${PN} += "${ROS_EXEC_DEPENDS}"
+
+#Disable the split of debug information into -dbg files
+INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
+
+SRC_URI = "git://github.com/qualcomm-qrb-ros/qrb_ros_nn_inference.git;protocol=https;branch=stable/1.0.0;subdir=${BPN}-${PV} \
+           file://0001-feat-replace-tflite-Cpp-API-to-C-API.patch;striplevel=2 \
+"
+SRCREV = "8fe767525171346fa00797c8eef1585746b299a9"
+S = "${UNPACKDIR}/${BPN}-${PV}/${ROS_CN}"
+
+ROS_BUILD_TYPE = "ament_cmake"
+
+inherit ros_${ROS_BUILD_TYPE}
+
+# QAIRT(QNN) headers are installed under ${includedir}/QNN/, but upstream includes
+# use e.g. #include "QnnInterface.h" (without QNN/ prefix). Add include path here.
+CPPFLAGS:append = " -I${RECIPE_SYSROOT}${includedir}/QNN"
+CXXFLAGS:append = " -I${RECIPE_SYSROOT}${includedir}/QNN"
+
+inherit robotics-package

--- a/recipes/qrb-ros-nn-inference/qrb-ros-nn-inference_0.0.0.1.bb
+++ b/recipes/qrb-ros-nn-inference/qrb-ros-nn-inference_0.0.0.1.bb
@@ -1,0 +1,67 @@
+inherit ros_distro_${ROS_DISTRO} pkgconfig
+inherit ros_component robotics-package
+
+DESCRIPTION = "Package for performing neural network model inference"
+AUTHOR = "Na Song <nasong@qti.qualcomm.com>"
+ROS_AUTHOR = "Na Song"
+SECTION = "devel"
+LICENSE = "BSD-3-Clause-Clear"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/${LICENSE};md5=7a434440b651f4a472ca93716d01033a"
+
+ROS_CN = "qrb_ros_nn_inference"
+ROS_BPN = "qrb_ros_nn_inference"
+
+ROS_BUILD_DEPENDS = " \
+    rclcpp \
+    std-msgs \
+    ament-index-cpp \
+    rclcpp-components \
+    qrb-inference-manager \
+    qrb-ros-tensor-list-msgs \
+"
+
+ROS_BUILDTOOL_DEPENDS = " \
+    ament-cmake-auto-native \
+"
+
+ROS_EXPORT_DEPENDS = " \
+    rclcpp \
+    ament-index-cpp \
+"
+
+ROS_BUILDTOOL_EXPORT_DEPENDS = ""
+
+ROS_EXEC_DEPENDS = " \
+    rclcpp \
+    rclcpp-components \
+    qrb-ros-tensor-list-msgs \
+"
+
+ROS_TEST_DEPENDS = " \
+    ament-lint-auto \
+    ament-lint-common \
+    ament-cmake-gtest \
+    ament-cmake-copyright \
+    ament-cmake-cppcheck \
+    ament-cmake-cpplint \
+    ament-cmake-flake8 \
+    ament-cmake-lint-cmake \
+    ament-cmake-pep257 \
+    ament-cmake-uncrustify \
+    ament-cmake-xmllint \
+    rclcpp-components \
+"
+
+DEPENDS = "${ROS_BUILD_DEPENDS} ${ROS_BUILDTOOL_DEPENDS}"
+DEPENDS += "${ROS_EXPORT_DEPENDS} ${ROS_BUILDTOOL_EXPORT_DEPENDS} ${ROS_TEST_DEPENDS}"
+
+RDEPENDS:${PN} += "${ROS_EXEC_DEPENDS}"
+
+SRC_URI = "git://github.com/qualcomm-qrb-ros/qrb_ros_nn_inference.git;protocol=https;branch=stable/1.0.0;subdir=${BPN}-${PV}"
+SRCREV = "8fe767525171346fa00797c8eef1585746b299a9"
+S = "${UNPACKDIR}/${BPN}-${PV}/${ROS_CN}"
+
+ROS_BUILD_TYPE = "ament_cmake"
+inherit ros_${ROS_BUILD_TYPE}
+
+inherit robotics-package


### PR DESCRIPTION
CRs-Fixed: 4487564

Motivation
This change adds recipe for [QRB ROS NN Inference](https://github.com/qualcomm-qrb-ros/qrb_ros_nn_inference) package and enable support for robotics-opensource set.

Impact
Consumers of the Robotics opensource packagegroup will automatically get qrb-ros-nn-inference