### PR TITLE
ci: update the commit ids of dependent layers(4/6/2026)

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -108,18 +108,18 @@ jobs:
           - name: qcom-robotics-distro-selinux
             yamlfile: ':ci/qcom-robotics-distro-selinux.yml'
         target:
-          - type: '+base'
+          - type: '_base'
             name: qcom-robotics-image
             yamlfile: ':ci/qcom-robotics-image.yml'
-          - type: '+full'
+          - type: '_full'
             name: qcom-robotics-proprietary-image
             yamlfile: ':ci/qcom-robotics-proprietary-image.yml'
         kernel:
           - type: default
-            dirname: '+linux-qcom-next'
+            dirname: '_linux-qcom-next'
             yamlfile: ''
           - type: 6.18
-            dirname: '+linux-qcom-lts'
+            dirname: '_linux-qcom-lts'
             yamlfile: ':ci/linux-qcom-6.18.yml'
     name: ${{ matrix.machine }}/${{ matrix.distro.name }}${{ matrix.target.type }}${{ matrix.kernel.dirname }}
     steps:

--- a/.github/workflows/monthly.yml
+++ b/.github/workflows/monthly.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   sstate-cache-cleanup:
     if: github.repository_owner == 'qualcomm-linux'
-    runs-on: [self-hosted, gen-qlnx-prd-u2404-x64-sm-od-ephe]
+    runs-on: [self-hosted, gen-qlnx-prd-u2404-x64-sm-od-ephem]    
     timeout-minutes: 720
     steps:
       - name: Clean up the persistant sstate-cache dir

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,9 +20,9 @@ jobs:
         distro:
           - name: qcom-robotics-distro
         target:
-          - type: '+full'
+          - type: '_full'
         kernel:
-          - dirname: '+linux-qcom-next'
+          - dirname: '_linux-qcom-next'
     steps:
       - uses: actions/checkout@v4
         with:

--- a/ci/lava/qcom-robotics-distro/iq-9075-evk/boot+linux-qcom-lts.yaml
+++ b/ci/lava/qcom-robotics-distro/iq-9075-evk/boot+linux-qcom-lts.yaml
@@ -4,7 +4,7 @@ actions:
       image:
         headers:
           Authentication: Q_GITHUB_TOKEN
-        url: "{{BUILD_DOWNLOAD_URL}}/qcom-robotics-distro+full+linux-qcom-lts/{{DEVICE_TYPE}}/qcom-robotics-proprietary-image-{{DEVICE_TYPE}}.rootfs.qcomflash.tar.gz"
+        url: "{{BUILD_DOWNLOAD_URL}}/qcom-robotics-distro_full_linux-qcom-lts/{{DEVICE_TYPE}}/qcom-robotics-proprietary-image-{{DEVICE_TYPE}}.rootfs.qcomflash.tar.gz"
     postprocess:
       docker:
         image: ghcr.io/foundriesio/lava-lmp-sign:main

--- a/ci/lava/qcom-robotics-distro/iq-9075-evk/boot.yaml
+++ b/ci/lava/qcom-robotics-distro/iq-9075-evk/boot.yaml
@@ -4,7 +4,7 @@ actions:
       image:
         headers:
           Authentication: Q_GITHUB_TOKEN
-        url: "{{BUILD_DOWNLOAD_URL}}/qcom-robotics-distro+full+linux-qcom-next/{{DEVICE_TYPE}}/qcom-robotics-proprietary-image-{{DEVICE_TYPE}}.rootfs.qcomflash.tar.gz"
+        url: "{{BUILD_DOWNLOAD_URL}}/qcom-robotics-distro_full_linux-qcom-next/{{DEVICE_TYPE}}/qcom-robotics-proprietary-image-{{DEVICE_TYPE}}.rootfs.qcomflash.tar.gz"
     postprocess:
       docker:
         image: ghcr.io/foundriesio/lava-lmp-sign:main

--- a/ci/qcom-robotics-distro.yml
+++ b/ci/qcom-robotics-distro.yml
@@ -10,7 +10,7 @@ repos:
 
   meta-qcom:
       url: https://github.com/qualcomm-linux/meta-qcom
-      commit: b765fe140e93ca1f6607c33f2a193bc545c9bc0d
+      commit: 9e45d0d0bd6984e1feff5444b51888f30b40886a
   oe-core:
       url: https://github.com/openembedded/openembedded-core
       layers:
@@ -19,16 +19,16 @@ repos:
           fix-BSD-license-missing:
               repo: meta-qcom-robotics-sdk
               path: patches/Initial-commit-of-license.patch
-      commit: 8061433fcd11eba91a29004dfafd175d449fb2fd
+      commit: e954a94b5b528b2430e8da331107d7d58287f89b
   bitbake:
       url: https://github.com/openembedded/bitbake
       layers:
           .: disabled
-      commit: e7d5e156275782948d3346f299780389ab263ab6
+      commit: 7fd4d9d10524ac798ba96057462ea77e6998b0ff
   meta-qcom-distro:
       url: https://github.com/qualcomm-linux/meta-qcom-distro
       branch: main
-      commit: a6a98025fab52a90c2c9517ca66cb8f1bf9a9b7a
+      commit: 2a1f1df35573e691f49c961ce3e5159d31ee3fc3
   meta-openembedded:
       url: https://github.com/openembedded/meta-openembedded
       layers:
@@ -39,34 +39,30 @@ repos:
           meta-oe:
           meta-python:
           meta-xfce:
-      commit: b883bd25cdd27560fdebc5a4bf56f90e99964c4c
+      commit: 6bc36f105c562e48b0feba2a026416d0942f2bd3
   meta-virtualization:
-      url: https://git.yoctoproject.org/git/meta-virtualization
+      url: https://git.yoctoproject.org/meta-virtualization
       branch: master
-      commit: 475530ac08ecf716917f48dfa60e0607d324ff9a
+      commit: f829fbfda0f14365235d48dbe2055121fbc0718c
   meta-audioreach:
       url: https://github.com/AudioReach/meta-audioreach
       branch: master
-      commit: 1d60c211c874bb342d27699e717d53bde94f7299
+      commit: 09a96ccfdcdd5d580c9779ac8089da6f408538ff
   meta-selinux:
       branch: master
       url: https://git.yoctoproject.org/meta-selinux
-      commit: 50803c3dd3d42bfe060b96a094c01d9075e37f41
+      commit: d836d252e9cb1c7a8778063288a501fda2095932
   meta-updater:
       branch: master
       url: https://github.com/uptane/meta-updater
-      commit: 399ca9f0b99a1b1fd38c27df7aa1bf21b232ba30
+      commit: f5eb3010d614c9a206ef05ff1c6a4ec1540ce6a8
   meta-security:
       url: https://git.yoctoproject.org/meta-security
       branch: master
-      patches:
-           plain:
-               repo: meta-qcom
-               path: 0001-meta-security-layers-update-for-wrynose-release-series.patch
       layers:
           .:
           meta-tpm:
-      commit: 0936595355433f9691fd30257743865b9ae27a1d
+      commit: 8028c573db6923525c2918724f2bd36d4a420e0b
 
   meta-ros:
       url: https://github.com/ros/meta-ros.git


### PR DESCRIPTION
CRs-Fixed: 4487408

Motivation
1. Update the robotics SDK's dependent layers to the commits as of 2026-04-06.
2. Update the sstate-cache-cleanup runner label.
3. The + character is a reserved character in S3 URL encoding rules, switch to underscore to work around such limitation.

Impact
1. LAVA test and Axiom test must update the download URL to fetch the build artifacts.
2. The Robotics SDK build will use the commit IDs from the meta-qcom​ nightly build on 2026-04-06.
meta-qcom nightly build url: https://github.com/qualcomm-linux/meta-qcom/actions/runs/24025504725
