### PR TITLE
feat: add nav2  bbappends and packagegroup integration

### DIFF
--- a/recipes-bbappends/recipe-ros/navigation2/control-toolbox_%.bbappend
+++ b/recipes-bbappends/recipe-ros/navigation2/control-toolbox_%.bbappend
@@ -1,0 +1,18 @@
+DEPENDS:append = " generate-parameter-library-native generate-parameter-library-py-native"
+
+EXTRA_OECMAKE:append = " \
+  -Dgenerate_parameter_library_cpp_BIN=${RECIPE_SYSROOT_NATIVE}${bindir}/generate_parameter_library_cpp \
+"
+
+do_configure:prepend() {
+    export PYTHONPATH="${RECIPE_SYSROOT_NATIVE}${PYTHON_SITEPACKAGES_DIR}:$PYTHONPATH"
+}
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+do_configure:append() {
+    if [ -f ${B}/build.ninja ]; then
+        sed -i -e 's/-Werror[^ ]*//g' ${B}/build.ninja
+    fi
+}
+

--- a/recipes-bbappends/recipe-ros/navigation2/controller-interface_%.bbappend
+++ b/recipes-bbappends/recipe-ros/navigation2/controller-interface_%.bbappend
@@ -1,0 +1,8 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+do_configure:append() {
+    if [ -f ${B}/build.ninja ]; then
+        sed -i -e 's/-Werror[^ ]*//g' ${B}/build.ninja
+    fi
+}
+

--- a/recipes-bbappends/recipe-ros/navigation2/diff-drive-controller_%.bbappend
+++ b/recipes-bbappends/recipe-ros/navigation2/diff-drive-controller_%.bbappend
@@ -1,0 +1,8 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+do_configure:append() {
+    if [ -f ${B}/build.ninja ]; then
+        sed -i -e 's/-Werror[^ ]*//g' ${B}/build.ninja
+    fi
+}
+

--- a/recipes-bbappends/recipe-ros/navigation2/gz-cmake-vendor_%.bbappend
+++ b/recipes-bbappends/recipe-ros/navigation2/gz-cmake-vendor_%.bbappend
@@ -1,0 +1,2 @@
+DEPENDS:append = " python3-vcstool-native python3-setuptools-native"
+

--- a/recipes-bbappends/recipe-ros/navigation2/hardware-interface_%.bbappend
+++ b/recipes-bbappends/recipe-ros/navigation2/hardware-interface_%.bbappend
@@ -1,0 +1,16 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+SRC_URI:remove = "file://use-tinyxml-by-name.patch"
+
+EXTRA_OECMAKE += "-Wno-error"
+
+CXXFLAGS:append = " -I${STAGING_INCDIR}/pal_statistics -I${STAGING_INCDIR}/pal_statistics/pal_statistics"
+
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+do_configure:append() {
+    if [ -f ${B}/build.ninja ]; then
+        sed -i -e 's/-Werror[^ ]*//g' ${B}/build.ninja
+    fi
+}
+

--- a/recipes-bbappends/recipe-ros/navigation2/joint-limits_%.bbappend
+++ b/recipes-bbappends/recipe-ros/navigation2/joint-limits_%.bbappend
@@ -1,0 +1,7 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+do_configure:append() {
+    if [ -f ${B}/build.ninja ]; then
+        sed -i -e 's/-Werror[^ ]*//g' ${B}/build.ninja
+    fi
+}

--- a/recipes-bbappends/recipe-ros/navigation2/joint-state-broadcaster_%.bbappend
+++ b/recipes-bbappends/recipe-ros/navigation2/joint-state-broadcaster_%.bbappend
@@ -1,0 +1,8 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+do_configure:append() {
+    if [ -f ${B}/build.ninja ]; then
+        sed -i -e 's/-Werror[^ ]*//g' ${B}/build.ninja
+    fi
+}
+

--- a/recipes-bbappends/recipe-ros/navigation2/nav2-bringup_%.bbappend
+++ b/recipes-bbappends/recipe-ros/navigation2/nav2-bringup_%.bbappend
@@ -1,0 +1,12 @@
+inherit robotics-package
+
+# Remove these to disable visualization functions in nav2(including gazebo), meanwhile solve the compile problems.
+ROS_EXEC_DEPENDS:remove = " \
+    slam-toolbox \
+    nav2-minimal-tb4-sim \
+    nav2-minimal-tb3-sim \
+    ros-gz-sim \
+    ros-gz-bridge \
+"
+
+PACKAGES = "qirf-${PN}"

--- a/recipes-bbappends/recipe-ros/navigation2/pal-statistics_%.bbappend
+++ b/recipes-bbappends/recipe-ros/navigation2/pal-statistics_%.bbappend
@@ -1,0 +1,10 @@
+# Repair the pal_statistics path to solve compile build problems
+do_install:append() {
+    if [ -d "${D}${ros_prefix}/include/pal_statistics/pal_statistics" ]; then
+        bbnote "Fixing pal_statistics header install layout"
+        install -d "${D}${ros_prefix}/include/pal_statistics"
+        cp -af "${D}${ros_prefix}/include/pal_statistics/pal_statistics/." \
+               "${D}${ros_prefix}/include/pal_statistics/"
+    fi
+}
+

--- a/recipes-bbappends/recipe-ros/navigation2/python3-vcstool/0001-Replace-pkg_resources-with-importlib.metadata.patch
+++ b/recipes-bbappends/recipe-ros/navigation2/python3-vcstool/0001-Replace-pkg_resources-with-importlib.metadata.patch
@@ -1,0 +1,36 @@
+From 2751fcd96e85e183c8c87ee1bc252d28634558b6 Mon Sep 17 00:00:00 2001
+From: Kas User <kas@example.com>
+Date: Thu, 9 Apr 2026 11:04:23 +0800
+Subject: [PATCH] Replace pkg_resources with importlib.metadata
+Upstream-Status: Pending
+---
+ vcstool/commands/help.py | 9 +++++----
+ 1 file changed, 5 insertions(+), 4 deletions(-)
+
+diff --git a/vcstool/commands/help.py b/vcstool/commands/help.py
+index ec7b469..47ec358 100644
+--- a/vcstool/commands/help.py
++++ b/vcstool/commands/help.py
+@@ -1,7 +1,7 @@
+ import argparse
+ import sys
+ 
+-from pkg_resources import load_entry_point
++from importlib.metadata import entry_points
+ from vcstool.clients import vcstool_clients
+ from vcstool.commands import vcstool_commands
+ from vcstool.streams import set_streams
+@@ -85,9 +85,10 @@ def get_entrypoint(command):
+                 '\nDid you mean one of these?\n' + '\n   '.join(commands),
+                 file=sys.stderr)
+         return None
+-
+-    return load_entry_point(
+-        'vcstool', 'console_scripts', 'vcs-' + commands[0])
++    for ep in entry_points(group='console_scripts'):
++        if ep.name == 'vcs-' + commands[0]:
++            return ep.load()
++    return None
+ 
+ 
+ def get_parser_with_command_only():

--- a/recipes-bbappends/recipe-ros/navigation2/python3-vcstool_%.bbappend
+++ b/recipes-bbappends/recipe-ros/navigation2/python3-vcstool_%.bbappend
@@ -1,0 +1,4 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "file://0001-Replace-pkg_resources-with-importlib.metadata.patch"
+

--- a/recipes-bbappends/recipe-ros/navigation2/ros2-control-cmake_%.bbappend
+++ b/recipes-bbappends/recipe-ros/navigation2/ros2-control-cmake_%.bbappend
@@ -1,0 +1,2 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+SRC_URI:remove = "file://0001-disable-compiler-warnings.patch"

--- a/recipes-products/packagegroups/packagegroup-robotics-opensource.bb
+++ b/recipes-products/packagegroups/packagegroup-robotics-opensource.bb
@@ -59,6 +59,7 @@ EXTERNAL_OPENSOURCE = " \
     orbbec-camera \
     cartographer \
     cartographer-ros \
+    nav2-bringup \
 "
 
 ROS_GST_BRIDGE = " \


### PR DESCRIPTION
CRs-Fixed: 4494899

Motivation:
This PR adds the relevant bbappend files to enable nav2-bringup in the build system.

Impact:
After this change, the nav2-bringup can be enabled and compiled as a standalone component through the build system.