### PR TITLE
 ci: update LAVA token

### DIFF
--- a/ci/lava/qcom-robotics-distro/iq-9075-evk/boot+linux-qcom-lts.yaml
+++ b/ci/lava/qcom-robotics-distro/iq-9075-evk/boot+linux-qcom-lts.yaml
@@ -3,7 +3,7 @@ actions:
     images:
       image:
         headers:
-          Authentication: Q_GITHUB_TOKEN
+          Authentication: Q_S3_TOKEN
         url: "{{BUILD_DOWNLOAD_URL}}/qcom-robotics-distro_full_linux-qcom-lts/{{DEVICE_TYPE}}/qcom-robotics-proprietary-image-{{DEVICE_TYPE}}.rootfs.qcomflash.tar.gz"
     postprocess:
       docker:

--- a/ci/lava/qcom-robotics-distro/iq-9075-evk/boot.yaml
+++ b/ci/lava/qcom-robotics-distro/iq-9075-evk/boot.yaml
@@ -3,7 +3,7 @@ actions:
     images:
       image:
         headers:
-          Authentication: Q_GITHUB_TOKEN
+          Authentication: Q_S3_TOKEN
         url: "{{BUILD_DOWNLOAD_URL}}/qcom-robotics-distro_full_linux-qcom-next/{{DEVICE_TYPE}}/qcom-robotics-proprietary-image-{{DEVICE_TYPE}}.rootfs.qcomflash.tar.gz"
     postprocess:
       docker:


### PR DESCRIPTION
CRs-Fixed: 4487408

Motivation:
- Update LAVA token with Q_S3_TOKEN to avoid fetch failure of build artifacts.

Impact:
- LAVA test job will be failed if still using out-of-date GITHUB_TOKEN.
Issue link: https://github.com/qualcomm-linux/meta-qcom-robotics-sdk/issues/179