### PR TITLE
chore: add preflight checks workflow and denpendabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # This points to .github/workflows
+    schedule:
+      interval: "daily"

--- a/.github/workflows/qcom-preflight-checks.yml
+++ b/.github/workflows/qcom-preflight-checks.yml
@@ -1,0 +1,24 @@
+name: QC Preflight Checks
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+jobs:
+  preflight:
+    name: Run QC Preflight Checks
+    uses: qualcomm/qcom-reusable-workflows/.github/workflows/reusable-qcom-preflight-checks-orchestrator.yml@v2
+    with:
+      enable-semgrep-scan: true
+      enable-dependency-review: true
+      enable-repolinter-check: true
+      enable-copyright-license-check: true
+      enable-commit-email-check: true
+      enable-commit-msg-check: false
+      enable-armor-checkers: false
+
+    permissions:
+      contents: read
+      security-events: write

--- a/ci/lava/qcom-robotics-distro/iq-9075-evk/boot+linux-qcom-lts.yaml
+++ b/ci/lava/qcom-robotics-distro/iq-9075-evk/boot+linux-qcom-lts.yaml
@@ -3,7 +3,7 @@ actions:
     images:
       image:
         headers:
-          Authentication: Q_S3_TOKEN
+          Authorization: Q_S3_TOKEN
         url: "{{BUILD_DOWNLOAD_URL}}/qcom-robotics-distro_full_linux-qcom-lts/{{DEVICE_TYPE}}/qcom-robotics-proprietary-image-{{DEVICE_TYPE}}.rootfs.qcomflash.tar.gz"
     postprocess:
       docker:

--- a/ci/lava/qcom-robotics-distro/iq-9075-evk/boot.yaml
+++ b/ci/lava/qcom-robotics-distro/iq-9075-evk/boot.yaml
@@ -3,7 +3,7 @@ actions:
     images:
       image:
         headers:
-          Authentication: Q_S3_TOKEN
+          Authorization: Q_S3_TOKEN
         url: "{{BUILD_DOWNLOAD_URL}}/qcom-robotics-distro_full_linux-qcom-next/{{DEVICE_TYPE}}/qcom-robotics-proprietary-image-{{DEVICE_TYPE}}.rootfs.qcomflash.tar.gz"
     postprocess:
       docker:


### PR DESCRIPTION
CRs-Fixed: 4487408

Motivation:
1. Add Dependabot configuration to automate dependency updates.
2. Add QC Preflight Checks GitHub Actions workflow using the latest reusable workflow (v2) to enforce required preflight validations for pull requests.

Impact:
1. Dependabot will check GitHub workflow dependencies daily.
2. The QC Preflight Checks workflow will scan code for all pull requests.

Additional Notes
This PR is intended to merge related changes by adding the CRs-Fixed number. It also corrects the branch parameter from main to master: 
https://github.com/qualcomm-linux/meta-qcom-robotics-sdk/pull/183
https://github.com/qualcomm-linux/meta-qcom-robotics-sdk/pull/182