### PR TITLE
fix: update sdk source code

### DIFF
--- a/.github/actions/compile/action.yml
+++ b/.github/actions/compile/action.yml
@@ -79,13 +79,12 @@ runs:
     - name: Kas build images
       shell: bash
       run: |
-        $KAS_CONTAINER build ci/mirror.yml:ci/${{ inputs.machine }}.yml${{ inputs.distro_yaml }}${{ inputs.target_yaml }}${{ inputs.kernel_yaml }}
+        $KAS_CONTAINER shell ci/mirror.yml:ci/${{ inputs.machine }}.yml${{ inputs.distro_yaml }}${{ inputs.target_yaml }}${{ inputs.kernel_yaml }} --command "\
+        bitbake ${{ inputs.target_name }} && bitbake ${{ inputs.target_name }} -c generate_qirp_sdk"
+        
         ci/kas-container-shell-helper.sh ci/yocto-pybootchartgui.sh
         mv $KAS_WORK_DIR/build/buildchart.svg .
-
-        # Build qir-sdk
-        $KAS_CONTAINER build ci/mirror.yml:ci/${{ inputs.machine }}.yml${{ inputs.distro_yaml }}${{ inputs.target_yaml }}${{ inputs.kernel_yaml }} --task generate_qirp_sdk
-
+       
     - uses: actions/upload-artifact@v6
       with:
         name: buildchart-${{ inputs.distro_name }}-${{ inputs.target_type }}-${{ inputs.kernel_dirname }}-${{ inputs.machine }}

--- a/classes/psdk-image.bbclass
+++ b/classes/psdk-image.bbclass
@@ -81,7 +81,7 @@ process_qir_samples() {
         source_dir="${DEPLOY_DIR}/sample_source_code/${name}"
         if [ -d "${source_dir}" ]; then
             bbnote "  Copying entire directory ${source_dir} to ${to_dir}/"
-            cp -rf "${source_dir}" "${to_dir}/"
+            cp -rf "${source_dir}" "${to_dir}/" 2>/dev/null || bbwarn "Failed to copy ${name}"
         else
             bbwarn "  Source directory ${source_dir} does not exist, skipping sample: $name"
         fi
@@ -293,6 +293,34 @@ python () {
                            ' {}:do_collect_rdepends'.format(pkg_group))
         
         bb.note("Added dependencies for {}: {}".format(pn, ", ".join(pkg_groups)))
+        
+        # Add dependencies on sample source code copy tasks
+        # Read content_config.json to get list of samples
+        import json
+        import os
+        
+        robotics_layer_dir = d.getVar("ROBIOTICS_LAYER_DIR")
+        config_file = os.path.join(robotics_layer_dir, "recipes-sdk/files/content_config.json")
+        
+        if os.path.exists(config_file):
+            try:
+                with open(config_file, 'r') as f:
+                    config_data = json.load(f)
+                
+                samples = config_data.get("samples", [])
+                sample_names = [sample.get("name") for sample in samples if sample.get("name")]
+                
+                if sample_names:
+                    bb.note("Adding dependencies on sample source copy tasks for: {}".format(", ".join(sample_names)))
+                    for sample_name in sample_names:
+                        d.appendVarFlag('do_generate_qirp_sdk', 'depends',
+                                       ' {}:do_copy_source_to_deploy'.format(sample_name))
+                else:
+                    bb.note("No samples found in content_config.json")
+            except Exception as e:
+                bb.warn("Failed to read or parse content_config.json: {}".format(str(e)))
+        else:
+            bb.warn("content_config.json not found at: {}".format(config_file))
 }
 
 SSTATETASKS += "do_generate_qirp_sdk "

--- a/classes/robotics-package.bbclass
+++ b/classes/robotics-package.bbclass
@@ -57,14 +57,14 @@ do_copy_source_to_deploy() {
     # Copy all files from S directory
     if [ -d "${S}" ]; then
         bbnote "Copying source files from ${S} to ${dest_dir}"
-        cp -r "${S}/"* "${dest_dir}/" 2>/dev/null || true
+        cp -r "${S}/"* "${dest_dir}/"
     else
         bbwarn "Source directory ${S} does not exist, skipping source copy"
     fi
 }
 
 # Add task: copy source to deploy directory after patching
-addtask do_copy_source_to_deploy after do_patch before do_configure
+addtask do_copy_source_to_deploy after do_compile before do_package
 
 AUTO_LIBNAME_PKGS = ""
 

--- a/recipes-sdk/files/content_config.json
+++ b/recipes-sdk/files/content_config.json
@@ -13,6 +13,22 @@
             "to": "qirp-samples/platform/"
         },
         {
+            "name": "ros-gst-bridge",
+            "to": "qirp-samples/platform/"
+        },
+        {
+            "name": "qrb-ros-benchmark",
+            "to": "qirp-samples/platform/"
+        },
+        {
+            "name": "qrb-ros-camera",
+            "to": "qirp-samples/platform/"
+        },
+        {
+            "name": "qrb-ros-nn-inference",
+            "to": "qirp-samples/platform/"
+        },
+        {
             "name": "simulation-sample-pick-and-place",
             "to": "qirp-samples/robotics"
         },
@@ -27,22 +43,6 @@
         {
             "name": "sample-face-detection",
             "to": "qirp-samples/ai_vision/"
-        },
-        {
-            "name": "ros-gst-bridge",
-            "to": "qirp-samples/platform/"
-        },
-        {
-            "name": "qrb-ros-benchmark",
-            "to": "qirp-samples/platform/"
-        },
-        {
-            "name": "rplidar-ros2",
-            "to": "qirp-samples/platform/"
-        },
-        {
-            "name": "qrb-ros-camera",
-            "to": "qirp-samples/platform/"
         }
       ],
       "scripts": [


### PR DESCRIPTION
CRs-Fixed: 4497681

Motivation:
The project previously used two separate kas containers, which prevented access to the build output artifacts during the QIRP SDK compilation.
Impact:
By merging the two tasks and executing them within a single kas container, the compilation output of the QIRP SDK is now properly generated and observable.