### PR TITLE
feat: enable sample-remote-assistant in opensource packagegroup

### DIFF
--- a/recipes-products/packagegroups/packagegroup-robotics-opensource.bb
+++ b/recipes-products/packagegroups/packagegroup-robotics-opensource.bb
@@ -49,6 +49,7 @@ QUALCOMM_QRB_ROS = " \
 # About qrb ros sample introduction, Please refer to https://github.com/qualcomm-qrb-ros/qrb_ros_samples.
 QRB_ROS_SAMPLE = " \
     simulation-sample-amr-simple-motion \
+    sample-remote-assistant \
 "
 
 # If you do not work within the above two organizations and are preparing to merge your code into the Qualcomm Linux Intelligence Robotics Image,

--- a/recipes-sdk/files/content_config.json
+++ b/recipes-sdk/files/content_config.json
@@ -43,7 +43,12 @@
         {
             "name": "qrb-ros-camera",
             "to": "qirp-samples/platform/"
+        },
+	{
+            "name": "sample-remote-assistant",
+            "to": "qirp-samples/robotics"
         }
+
       ],
       "scripts": [
         {

--- a/recipes/qrb-ros-samples/sample-remote-assistant_0.0.1.bb
+++ b/recipes/qrb-ros-samples/sample-remote-assistant_0.0.1.bb
@@ -3,7 +3,7 @@ ROS_BUILD_TYPE = "ament_python"
 ROS_CN = "simulation_remote_assistant"
 ROS_BPN = "simulation_remote_assistant"
 
-S = "${WORKDIR}/git/robotics/${ROS_CN}"
+S = "${UNPACKDIR}/${PN}-${PV}/robotics/${ROS_CN}"
 
 ROS_BUILD_DEPENDS = " \
 "


### PR DESCRIPTION
CRs-Fixed: 4501586

Motivation
This change enables sample-remote-assistant in robotics-opensource set.

Impact
The robotics image will include this sample and consumers of the robotics opensource packagegroup will automatically get it.