### PR TITLE
fix: delete samples from package group

### DIFF
--- a/recipes-products/packagegroups/packagegroup-oss-with-prop-deps.bb
+++ b/recipes-products/packagegroups/packagegroup-oss-with-prop-deps.bb
@@ -25,8 +25,6 @@ QUALCOMM_QRB_ROS = " \
 # If it is qrb ros sample, Please place all of them under this variable.
 # About qrb ros sample introduction, Please refer to https://github.com/qualcomm-qrb-ros/qrb_ros_samples.
 QRB_ROS_SAMPLE = " \
-    sample-hrnet-pose-estimation \
-    sample-face-detection \
     simulation-sample-pick-and-place \
 "
 

--- a/recipes-products/packagegroups/packagegroup-robotics-opensource.bb
+++ b/recipes-products/packagegroups/packagegroup-robotics-opensource.bb
@@ -24,8 +24,8 @@ QUALCOMM_QRB_ROS = " \
     qrb-ros-transport-imu-type \
     qrb-ros-transport-point-cloud2-type \
     qrb-sensor-client \
-	qrb-ros-system-monitor \
-	qrb-ros-system-monitor-interfaces \
+    qrb-ros-system-monitor \
+    qrb-ros-system-monitor-interfaces \
     qrb-ros-docker \
     libqrc \
     libqrc-udriver \

--- a/recipes/qrb-ros-samples/include/qrb-ros-samples.inc
+++ b/recipes/qrb-ros-samples/include/qrb-ros-samples.inc
@@ -4,9 +4,6 @@ HOMEPAGE = "https://github.com/qualcomm-qrb-ros/qrb_ros_samples"
 LICENSE = "BSD-3-Clause-Clear"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/BSD-3-Clause-Clear;md5=7a434440b651f4a472ca93716d01033a"
 
-SRC_URI = "git://github.com/qualcomm-qrb-ros/qrb_ros_samples.git;protocol=https;branch=jazzy-rel"
-SRCREV = "${QRB_ROS_SAMPLE_REV}"
-
 inherit ros_${ROS_BUILD_TYPE}
 inherit ros_distro_${ROS_DISTRO} pkgconfig
 inherit ros_component robotics-package

--- a/recipes/qrb-ros-samples/simulation-sample-amr-simple-motion_1.0.0.bb
+++ b/recipes/qrb-ros-samples/simulation-sample-amr-simple-motion_1.0.0.bb
@@ -3,7 +3,10 @@ ROS_BUILD_TYPE = "ament_python"
 ROS_CN = "simulation_sample_amr_simple_motion"
 ROS_BPN = "simulation_sample_amr_simple_motion"
 
-S = "${UNPACKDIR}/${PN}-${PV}/robotics/${ROS_CN}"
+SRC_URI = "git://github.com/qualcomm-qrb-ros/qrb_ros_samples.git;protocol=https;branch=stable-simulation_sample_amr_simple_motion/1.0.0"
+
+SRCREV = "253360c77d6d004ee997211ee7b1bcaefb01c2ae"
+
 
 ROS_BUILD_DEPENDS = " \
 "


### PR DESCRIPTION
Motivation:
Delete sample from package group due to fetch source not stable branch.

Impact:
Image and RP SDK not include the deleted samples.