### PR TITLE
ci(automation): update the commit id from meta-qcom: 24477114180

### DIFF
--- a/ci/qcom-robotics-distro.yml
+++ b/ci/qcom-robotics-distro.yml
@@ -6,7 +6,7 @@ repos:
   meta-qcom-robotics-sdk:
   meta-qcom:
     url: https://github.com/qualcomm-linux/meta-qcom
-    commit: f14dfcaed14cc50af13e8483a147ef1d98c7c03a
+    commit: db253c136ea26bfb6caade9d319863dac516c363
   oe-core:
     url: https://github.com/openembedded/openembedded-core
     layers:
@@ -24,7 +24,7 @@ repos:
   meta-qcom-distro:
     url: https://github.com/qualcomm-linux/meta-qcom-distro
     branch: main
-    commit: dc4051f119c08e081dfa932567ee6d88f32d1c54
+    commit: 4297bce9383ea57a822582ee23304216a10108fa
   meta-openembedded:
     url: https://github.com/openembedded/meta-openembedded
     layers:


### PR DESCRIPTION
## Auto-update from meta-qcom Nightly Build

This pull request automatically updates the repository commits from the latest meta-qcom nightly build.

**Build Details:**
- meta-qcom nightly build url: https://github.com/qualcomm-linux/meta-qcom/actions/runs/24477114180
- Check and download actions url: https://github.com/DotaIsMind/meta-qcom-robotics-sdk/actions/runs/24482428873
- Timestamp: Wed Apr 15 22:51:02 UTC 2026