### PR TITLE
feat: enable samples

### DIFF
--- a/recipes-products/packagegroups/packagegroup-oss-with-prop-deps.bb
+++ b/recipes-products/packagegroups/packagegroup-oss-with-prop-deps.bb
@@ -26,6 +26,10 @@ QUALCOMM_QRB_ROS = " \
 # About qrb ros sample introduction, Please refer to https://github.com/qualcomm-qrb-ros/qrb_ros_samples.
 QRB_ROS_SAMPLE = " \
     simulation-sample-pick-and-place \
+    sample-hand-detection \
+    sample-object-detection \
+    sample-object-segmentation \
+    sample-resnet101 \
 "
 
 # If you do not work within the above two organizations and are preparing to merge your code into the Qualcomm Linux Intelligence Robotics Image, 

--- a/recipes-sdk/files/content_config.json
+++ b/recipes-sdk/files/content_config.json
@@ -35,6 +35,22 @@
         {
             "name": "simulation-sample-amr-simple-motion",
             "to": "qirp-samples/robotics"
+        },
+	{
+            "name": "sample-hand-detection",
+            "to": "qirp-samples/ai_vision"
+        },
+	{
+            "name": "sample-object-detection",
+            "to": "qirp-samples/ai_vision"
+        },
+	{
+            "name": "sample-object-segmentation",
+            "to": "qirp-samples/ai_vision"
+        },
+	{
+            "name": "sample-resnet101",
+            "to": "qirp-samples/ai_vision"
         }
       ],
       "scripts": [

--- a/recipes/qrb-ros-samples/sample-hand-detection_1.0.0.bb
+++ b/recipes/qrb-ros-samples/sample-hand-detection_1.0.0.bb
@@ -7,8 +7,6 @@ ROS_BUILD_TYPE = "ament_python"
 ROS_CN = "sample_hand_detection"
 ROS_BPN = "sample_hand_detection"
 
-S = "${UNPACKDIR}/${PN}-${PV}/ai_vision/${ROS_CN}"
-
 ROS_BUILD_DEPENDS = " \
 "
 

--- a/recipes/qrb-ros-samples/sample-object-detection_1.0.0.bb
+++ b/recipes/qrb-ros-samples/sample-object-detection_1.0.0.bb
@@ -1,7 +1,7 @@
 ROS_BUILD_TYPE = "ament_python"
 
-ROS_CN = "sample_object_detction"
-ROS_BPN = "sample_object_detction"
+ROS_CN = "sample_object_detection"
+ROS_BPN = "sample_object_detection"
 
 SRC_URI = "git://github.com/qualcomm-qrb-ros/qrb_ros_samples.git;protocol=https;branch=stable-sample_object_detection/1.0.0"
 


### PR DESCRIPTION
Motivation:
Enable the following samples in the SDK:
- sample_hand_detection
- sample_object_detection
- sample_object_segmentation
- sample_resnet101

Impact:
The SDK and robotics image will include the samples listed above.


CRs-Fixed: 4506442