### PR TITLE
chore: add gfortran as compile dependency for meta-ros

### DIFF
--- a/.github/actions/compile/action.yml
+++ b/.github/actions/compile/action.yml
@@ -80,6 +80,7 @@ runs:
       shell: bash
       run: |
         $KAS_CONTAINER shell ci/mirror.yml:ci/${{ inputs.machine }}.yml${{ inputs.distro_yaml }}${{ inputs.target_yaml }}${{ inputs.kernel_yaml }} --command "\
+        sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends gfortran && \
         bitbake ${{ inputs.target_name }} && bitbake ${{ inputs.target_name }} -c generate_qirp_sdk"
         
         ci/kas-container-shell-helper.sh ci/yocto-pybootchartgui.sh

--- a/ci/qcom-robotics-distro.yml
+++ b/ci/qcom-robotics-distro.yml
@@ -79,10 +79,7 @@ repos:
       ament_cmake_py_fix:
         repo: meta-qcom-robotics-sdk
         path: patches/0001-ros2-ament_cmake-add-python-configurations-for-class.patch
-      qcom-fixes4:
-        repo: meta-qcom-robotics-sdk
-        path: patches/0001-fix-Update-LAYERSERIES_COMPAT-to-adapt-to-upstream-u.patch
-    commit: fceba46917fe9473e64534d972d3cf853aa7674d
+    commit: eae6fa810b457c512861efa0d826abab707fa642
 local_conf_header:
   resource_limitation: '# Capture the count of cpu cores available from the host.
 


### PR DESCRIPTION
CRs-Fixed: 4487408

Motivation:
- Add gfortran to the build dependencies required for compiling meta-ros recipes.

Impact:
- gfortran package will be installed in CI build host server.

Dependency:
- gfortran is required by this PR for updating meta-ros revision. https://github.com/qualcomm-linux/meta-qcom-robotics-sdk/pull/208