### PR TITLE
feat: enable depth estimation sample on mainline0.0

### DIFF
--- a/recipes-products/packagegroups/packagegroup-oss-with-prop-deps.bb
+++ b/recipes-products/packagegroups/packagegroup-oss-with-prop-deps.bb
@@ -25,11 +25,11 @@ QUALCOMM_QRB_ROS = " \
 # If it is qrb ros sample, Please place all of them under this variable.
 # About qrb ros sample introduction, Please refer to https://github.com/qualcomm-qrb-ros/qrb_ros_samples.
 QRB_ROS_SAMPLE = " \
-    simulation-sample-pick-and-place \
     sample-hand-detection \
     sample-object-detection \
     sample-object-segmentation \
     sample-resnet101 \
+    sample-depth-estimation \
 "
 
 # If you do not work within the above two organizations and are preparing to merge your code into the Qualcomm Linux Intelligence Robotics Image, 

--- a/recipes-products/packagegroups/packagegroup-robotics-opensource.bb
+++ b/recipes-products/packagegroups/packagegroup-robotics-opensource.bb
@@ -50,6 +50,7 @@ QUALCOMM_QRB_ROS = " \
 QRB_ROS_SAMPLE = " \
     simulation-sample-amr-simple-motion \
     sample-remote-assistant \
+    simulation-sample-pick-and-place \
 "
 
 # If you do not work within the above two organizations and are preparing to merge your code into the Qualcomm Linux Intelligence Robotics Image,

--- a/recipes-sdk/files/content_config.json
+++ b/recipes-sdk/files/content_config.json
@@ -36,25 +36,29 @@
             "name": "simulation-sample-amr-simple-motion",
             "to": "qirp-samples/robotics"
         },
-        {
+	      {
             "name": "sample-hand-detection",
             "to": "qirp-samples/ai_vision"
         },
-        {
+	      {
             "name": "sample-object-detection",
             "to": "qirp-samples/ai_vision"
         },
-        {
+	      {
             "name": "sample-object-segmentation",
             "to": "qirp-samples/ai_vision"
         },
-        {
+	      {
             "name": "sample-resnet101",
             "to": "qirp-samples/ai_vision"
         },
         {
             "name": "sample-remote-assistant",
             "to": "qirp-samples/robotics"
+        },
+        {
+            "name": "sample-depth-estimation",
+            "to": "qirp-samples/ai_vision"
         }
       ],
       "scripts": [

--- a/recipes/qrb-ros-samples/sample-depth-estimation_1.0.1.bb
+++ b/recipes/qrb-ros-samples/sample-depth-estimation_1.0.1.bb
@@ -1,9 +1,15 @@
+LICENSE = "BSD-3-Clause-Clear"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/BSD-3-Clause-Clear;md5=7a434440b651f4a472ca93716d01033a"
+
+# ROS_BUILD_TYPE definition before require action
 ROS_BUILD_TYPE = "ament_python"
 
 ROS_CN = "sample_depth_estimation"
 ROS_BPN = "sample_depth_estimation"
 
-S = "${WORKDIR}/git/ai_vision/${ROS_CN}"
+SRC_URI = "git://github.com/qualcomm-qrb-ros/qrb_ros_samples.git;protocol=https;branch=stable-sample_depth_estimation/1.0.0"
+
+SRCREV = "315c7813ffed90222fbf7230f1ae2f85bdaf9613"
 
 ROS_BUILD_DEPENDS = " \
 "
@@ -11,6 +17,7 @@ ROS_BUILD_DEPENDS = " \
 ROS_BUILDTOOL_DEPENDS = " \
     ament-cmake-python \
     ament-index-python \
+    python3-setuptools \
 "
 
 ROS_EXPORT_DEPENDS = " \
@@ -23,6 +30,7 @@ ROS_EXEC_DEPENDS = " \
     python3 \
     python3-numpy \
     python3-pybind11 \
+    python3-setuptools \
 "
 
 ROS_TEST_DEPENDS = " \
@@ -34,3 +42,5 @@ DEPENDS = "${ROS_BUILD_DEPENDS} ${ROS_BUILDTOOL_DEPENDS} ${ROS_EXPORT_DEPENDS} $
 RDEPENDS:${PN} += "${ROS_EXEC_DEPENDS}"
 
 require include/qrb-ros-samples.inc
+
+

--- a/recipes/qrb-ros-samples/simulation-sample-pick-and-place_1.0.1.bb
+++ b/recipes/qrb-ros-samples/simulation-sample-pick-and-place_1.0.1.bb
@@ -2,7 +2,6 @@ LICENSE = "BSD-3-Clause-Clear"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/BSD-3-Clause-Clear;md5=7a434440b651f4a472ca93716d01033a"
 
 inherit ros_distro_${ROS_DISTRO}
-inherit ros_component
 inherit ros_component robotics-package
 
 ROS_BUILD_TYPE = "ament_cmake"


### PR DESCRIPTION
CRs-Fixed: 4508402

Motivation:
- Add support for running the depth estimation ROS Jazzy sample on the mainline0.0 platform.
- Correct the simulation sample pick and place packagegroup.

Impact:
- The depth estimation sample will be installed to `/opt/ros/jazzy/lib` and will run out-of-the-box.