### PR TITLE
feat: enable sample-hrnet-pose-estimation

### DIFF
--- a/recipes-products/packagegroups/packagegroup-oss-with-prop-deps.bb
+++ b/recipes-products/packagegroups/packagegroup-oss-with-prop-deps.bb
@@ -30,6 +30,7 @@ QRB_ROS_SAMPLE = " \
     sample-object-detection \
     sample-object-segmentation \
     sample-resnet101 \
+    sample-hrnet-pose-estimation \
 "
 
 # If you do not work within the above two organizations and are preparing to merge your code into the Qualcomm Linux Intelligence Robotics Image, 

--- a/recipes-sdk/files/content_config.json
+++ b/recipes-sdk/files/content_config.json
@@ -36,21 +36,25 @@
             "name": "simulation-sample-amr-simple-motion",
             "to": "qirp-samples/robotics"
         },
-	{
+	    {
             "name": "sample-hand-detection",
             "to": "qirp-samples/ai_vision"
         },
-	{
+	    {
             "name": "sample-object-detection",
             "to": "qirp-samples/ai_vision"
         },
-	{
+	    {
             "name": "sample-object-segmentation",
             "to": "qirp-samples/ai_vision"
         },
-	{
+	    {
             "name": "sample-resnet101",
             "to": "qirp-samples/ai_vision"
+        },
+        {
+            "name": "sample-hrnet-pose-estimation",
+            "to": "qirp-samples/ai_vision/"
         }
       ],
       "scripts": [

--- a/recipes/qrb-ros-samples/sample-hrnet-pose-estimation_1.0.0.bb
+++ b/recipes/qrb-ros-samples/sample-hrnet-pose-estimation_1.0.0.bb
@@ -3,7 +3,8 @@ ROS_BUILD_TYPE = "ament_python"
 ROS_CN = "sample_hrnet_pose_estimation"
 ROS_BPN = "sample_hrnet_pose_estimation"
 
-S = "${UNPACKDIR}/${PN}-${PV}/ai_vision/${ROS_CN}"
+SRC_URI = "git://github.com/qualcomm-qrb-ros/qrb_ros_samples.git;protocol=https;branch=stable-sample_hrnet_pose_estimation/1.0.0"
+SRCREV = "c30b0c2f676d9ac94965c0bdcd7446a3531029dc"
 
 ROS_BUILD_DEPENDS = " \
 "


### PR DESCRIPTION
CRs-Fixed: 4509459

Motivation:
Add support for running the hrnet pose estimation ROS Jazzy sample on the mainline0.0 platform.

Impact:
The hrnet pose estimation sample will be installed to /opt/ros/jazzy/lib and will package to qirp sdk.