### PR TITLE
feat: enable sample-face-detection on mainline0.0

### DIFF
--- a/recipes-products/packagegroups/packagegroup-oss-with-prop-deps.bb
+++ b/recipes-products/packagegroups/packagegroup-oss-with-prop-deps.bb
@@ -32,6 +32,7 @@ QRB_ROS_SAMPLE = " \
     sample-object-segmentation \
     sample-resnet101 \
     sample-hrnet-pose-estimation \
+    sample-face-detection \
 "
 
 # If you do not work within the above two organizations and are preparing to merge your code into the Qualcomm Linux Intelligence Robotics Image, 

--- a/recipes-sdk/files/content_config.json
+++ b/recipes-sdk/files/content_config.json
@@ -36,15 +36,15 @@
             "name": "simulation-sample-amr-simple-motion",
             "to": "qirp-samples/robotics"
         },
-        {
+	    {
             "name": "sample-hand-detection",
             "to": "qirp-samples/ai_vision"
         },
-        {
+	    {
             "name": "sample-object-detection",
             "to": "qirp-samples/ai_vision"
         },
-        {
+	    {
             "name": "sample-object-segmentation",
             "to": "qirp-samples/ai_vision"
         },
@@ -59,6 +59,10 @@
         {
             "name": "sample-remote-assistant",
             "to": "qirp-samples/robotics"
+        },
+        {
+            "name": "sample-face-detection",
+            "to": "qirp-samples/ai_vision"
         }
       ],
       "scripts": [

--- a/recipes/qrb-ros-samples/sample-face-detection_0.0.1.bb
+++ b/recipes/qrb-ros-samples/sample-face-detection_0.0.1.bb
@@ -1,9 +1,10 @@
 ROS_BUILD_TYPE = "ament_python"
 
 ROS_CN = "sample_face_detection"
-ROS_BPN = ""sample_face_detection""
+ROS_BPN = "sample_face_detection"
 
-S = "${UNPACKDIR}/${PN}-${PV}/ai_vision/${ROS_CN}"
+SRC_URI = "git://github.com/qualcomm-qrb-ros/qrb_ros_samples.git;protocol=https;branch=stable-sample_face_detection/1.0.1"
+SRCREV = "0e05cb6042debdeb23dcdc09ed6d46a7cb8dafd7"
 
 ROS_BUILD_DEPENDS = " \
 "


### PR DESCRIPTION

CRs-Fixed: 4509740

Motivation:
  Add support for running the sample face detection with ROS Jazzy on the mainline0.0 platform.

Impact:
  The sample face detection will be installed to /opt/ros/jazzy/lib and will package to qirp sdk.