### PR TITLE
fix: declared branches of meta-qcom-robotics-sdk

### DIFF
--- a/ci/qcom-robotics-distro.yml
+++ b/ci/qcom-robotics-distro.yml
@@ -4,6 +4,7 @@ header:
   - ci/qcom-distro.yml
 repos:
   meta-qcom-robotics-sdk:
+    branch: main
   meta-qcom:
     url: https://github.com/qualcomm-linux/meta-qcom
     commit: fcce55a9439d2031092dc691263cd51eed813586


### PR DESCRIPTION
CRs-Fixed: 4510095

### Motivation:

Fix kas download meta-qcom-robotics-sdk branch error issue

### Impact:
KAS sync will download meta-qcom-robotics-sdk main branch by default in Mainline0.0.