### PR TITLE
feat: enable qrb-ros-audio-service node

### DIFF
--- a/recipes-products/packagegroups/packagegroup-oss-with-prop-deps.bb
+++ b/recipes-products/packagegroups/packagegroup-oss-with-prop-deps.bb
@@ -20,6 +20,7 @@ QUALCOMM_QRB_ROS = " \
     qrb-ros-colorspace-convert \
     qrb-ros-camera \
     qrb-ros-video \
+    qrb-ros-audio-service \
 "
 
 # If it is qrb ros sample, Please place all of them under this variable.

--- a/recipes/qrb-ros-audio-service/files/0001-fix-record-volume-too-low.patch
+++ b/recipes/qrb-ros-audio-service/files/0001-fix-record-volume-too-low.patch
@@ -1,0 +1,48 @@
+From 00747de8358ec7bab4c07749f198d2da7bf7416b Mon Sep 17 00:00:00 2001
+From: Ronghui Zhu <ronghuiz@qti.qualcomm.com>
+Date: Tue, 21 Apr 2026 17:43:06 +0800
+Subject: [PATCH] fix: record volume too low
+
+Upstream-Status: Inappropriate [platform-specific workaround]
+
+---
+ .../include/qrb_audio_common_lib/audio_common.hpp            | 1 +
+ qrb_audio_common_lib/src/capture_stream.cpp                  | 5 +++--
+ 2 files changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/qrb_audio_common_lib/include/qrb_audio_common_lib/audio_common.hpp b/qrb_audio_common_lib/include/qrb_audio_common_lib/audio_common.hpp
+index 2068c04..5ab31cb 100644
+--- a/qrb_audio_common_lib/include/qrb_audio_common_lib/audio_common.hpp
++++ b/qrb_audio_common_lib/include/qrb_audio_common_lib/audio_common.hpp
+@@ -26,6 +26,7 @@ namespace audio_common_lib
+ #define TIME_EVENT_USEC 50000
+ #define STREAM_VOL_MAX 100
+ #define STREAM_VOL_MIN 0
++#define RECORD_GAIN 8
+ 
+ #define LOG_ERROR (0x1)
+ #define LOG_INFO (0x2)
+diff --git a/qrb_audio_common_lib/src/capture_stream.cpp b/qrb_audio_common_lib/src/capture_stream.cpp
+index 0976971..f800338 100644
+--- a/qrb_audio_common_lib/src/capture_stream.cpp
++++ b/qrb_audio_common_lib/src/capture_stream.cpp
+@@ -64,7 +64,8 @@ int CaptureStream::start_stream()
+   buffer_attr.fragsize = buffer_attr.tlength = (uint32_t)-1;
+   buffer_attr.minreq = (uint32_t)-1;
+ 
+-  pa_cvolume_set(&volume, m_sample_spec->channels, PA_VOLUME_NORM * mvolume / STREAM_VOL_MAX);
++  pa_cvolume_set(&volume, m_sample_spec->channels, PA_VOLUME_NORM * mvolume / STREAM_VOL_MAX
++                * RECORD_GAIN);
+ 
+   if (pa_stream_connect_record(stream, /*device*/ nullptr, &buffer_attr, flags)) {
+     LOGE("pa_stream_connect_playback() failed: %s",
+@@ -180,4 +181,4 @@ void CaptureStream::stream_data_callback(pa_stream * stream, size_t length, void
+ }
+ 
+ }  // namespace audio_common_lib
+-}  // namespace qrb
+\ No newline at end of file
++}  // namespace qrb
+-- 
+2.34.1
+

--- a/recipes/qrb-ros-audio-service/qrb-audio-common-lib_1.0.3.bb
+++ b/recipes/qrb-ros-audio-service/qrb-audio-common-lib_1.0.3.bb
@@ -1,0 +1,28 @@
+inherit pkgconfig cmake
+
+DESCRIPTION = "QRB Audio Common library"
+AUTHOR = "Ronghui Zhu <quic_ronghuiz@quicinc.com>"
+ROS_AUTHOR = "Ronghui Zhu"
+SECTION = "devel"
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://../LICENSE;md5=68c28a8a26024c85c589d0de638520b6"
+
+PV = "1.0.3"
+
+DEPENDS = "glog gflags"
+
+SRC_URI = "git://github.com/quic-qrb-ros/qrb_ros_audio_service.git;protocol=https;branch=stable/1.0.3 \
+           file://0001-fix-record-volume-too-low.patch;striplevel=2 \
+           "
+
+SRCREV = "7a6e720cbd0a649432461a41069e880647c5c2be"
+S = "${UNPACKDIR}/${BP}/qrb_audio_common_lib"
+
+DEPENDS += " \
+    pulseaudio \
+    libsndfile1 \
+"
+
+EXTRA_OECMAKE:append = " -DBUILD_TESTING=OFF"
+
+FILES:${PN}-dev += "${datadir}"

--- a/recipes/qrb-ros-audio-service/qrb-audio-service-lib_1.0.3.bb
+++ b/recipes/qrb-ros-audio-service/qrb-audio-service-lib_1.0.3.bb
@@ -1,0 +1,25 @@
+inherit pkgconfig cmake
+
+DESCRIPTION = "QRB Audio Service library"
+AUTHOR = "Ronghui Zhu <quic_ronghuiz@quicinc.com>"
+ROS_AUTHOR = "Ronghui Zhu"
+SECTION = "devel"
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://../LICENSE;md5=68c28a8a26024c85c589d0de638520b6"
+
+PV = "1.0.3"
+
+DEPENDS = "glog gflags"
+
+SRC_URI = "git://github.com/quic-qrb-ros/qrb_ros_audio_service.git;protocol=https;branch=stable/1.0.3"
+
+SRCREV = "7a6e720cbd0a649432461a41069e880647c5c2be"
+S = "${UNPACKDIR}/${BP}/qrb_audio_manager"
+
+DEPENDS += " \
+    qrb-audio-common-lib \
+"
+
+EXTRA_OECMAKE:append = " -DBUILD_TESTING=OFF"
+
+FILES:${PN}-dev += "${datadir}"

--- a/recipes/qrb-ros-audio-service/qrb-ros-audio-common-msgs_0.2.0.bb
+++ b/recipes/qrb-ros-audio-service/qrb-ros-audio-common-msgs_0.2.0.bb
@@ -1,0 +1,53 @@
+inherit ros_distro_${ROS_DISTRO}
+inherit ros_component
+
+DESCRIPTION = "QRB ROS Audio Common Messages"
+AUTHOR           = "Ronghui Zhu <ronghuiz@qti.qualcomm.com>"
+ROS_AUTHOR       = "Ronghui Zhu"
+SECTION          = "devel"
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://../../LICENSE;md5=86fcc2294062130b497ba0ffff9f82fc"
+
+ROS_CN = "qrb_ros_audio_common_msgs"
+ROS_BPN = "qrb_ros_audio_common_msgs"
+
+ROS_BUILD_DEPENDS = " \
+    std-msgs \
+    action-msgs \
+    rosidl-default-generators-native \
+"
+
+ROS_BUILDTOOL_DEPENDS = " \
+    ament-cmake-auto-native \
+    rosidl-default-generators-native \
+"
+
+ROS_EXEC_DEPENDS = " \
+    builtin-interfaces \
+    rosidl-default-runtime \
+    std-msgs \
+    rcl-interfaces \
+"
+
+ROS_EXPORT_DEPENDS = " \
+    std-msgs \
+    action-msgs \
+    rosidl-default-generators-native \
+"
+
+ROS_BUILDTOOL_EXPORT_DEPENDS = ""
+
+DEPENDS = "${ROS_BUILD_DEPENDS} ${ROS_BUILDTOOL_DEPENDS}"
+DEPENDS += "${ROS_EXPORT_DEPENDS} ${ROS_BUILDTOOL_EXPORT_DEPENDS}"
+
+RDEPENDS:${PN} += "${ROS_EXEC_DEPENDS}"
+
+SRC_URI = "git://github.com/qualcomm-qrb-ros/qrb_ros_interfaces.git;protocol=https;branch=stable/0.2.0"
+SRCREV = "58afc211200aee777d16ce9b9e916f645de44190"
+S = "${UNPACKDIR}/${BP}/qrb_ros_audio_service_msgs/qrb_ros_audio_common_msgs"
+
+ROS_BUILD_TYPE = "ament_cmake"
+
+inherit ros_${ROS_BUILD_TYPE}
+
+inherit robotics-package

--- a/recipes/qrb-ros-audio-service/qrb-ros-audio-common_1.0.3.bb
+++ b/recipes/qrb-ros-audio-service/qrb-ros-audio-common_1.0.3.bb
@@ -1,0 +1,53 @@
+inherit ros_distro_${ROS_DISTRO}
+inherit ros_component
+inherit ros_insane_dev_so
+inherit pkgconfig
+
+DESCRIPTION = "QRB ROS Audio Common"
+AUTHOR = "Ronghui Zhu <ronghuiz@qti.qualcomm.com>"
+ROS_AUTHOR = "Ronghui Zhu"
+SECTION = "devel"
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://../LICENSE;md5=68c28a8a26024c85c589d0de638520b6"
+
+ROS_CN = "qrb_ros_audio_common"
+ROS_BPN = "qrb_ros_audio_common"
+
+ROS_BUILD_DEPENDS = " \
+    rclcpp \
+    rclcpp-components \
+    rclcpp-action \
+    qrb-audio-common-lib \
+    qrb-ros-audio-common-msgs \
+"
+
+ROS_BUILDTOOL_DEPENDS = " \
+    ament-cmake-auto-native \
+    rosidl-default-generators-native \
+"
+
+ROS_EXPORT_DEPENDS = ""
+
+ROS_BUILDTOOL_EXPORT_DEPENDS = ""
+
+ROS_EXEC_DEPENDS = " \
+    rclcpp \
+    qrb-audio-common-lib \
+    qrb-ros-audio-common-msgs \
+"
+
+DEPENDS = "${ROS_BUILD_DEPENDS} ${ROS_BUILDTOOL_DEPENDS}"
+DEPENDS += "${ROS_EXPORT_DEPENDS} ${ROS_BUILDTOOL_EXPORT_DEPENDS}"
+
+RDEPENDS:${PN} += "${ROS_EXEC_DEPENDS}"
+
+SRC_URI = "git://github.com/quic-qrb-ros/qrb_ros_audio_service.git;protocol=https;branch=stable/1.0.3"
+SRCREV = "7a6e720cbd0a649432461a41069e880647c5c2be"
+S = "${UNPACKDIR}/${BP}/qrb_ros_audio_common"
+PV = "1.0.3"
+
+ROS_BUILD_TYPE = "ament_cmake"
+
+inherit ros_${ROS_BUILD_TYPE}
+
+inherit robotics-package

--- a/recipes/qrb-ros-audio-service/qrb-ros-audio-service-msgs_0.2.0.bb
+++ b/recipes/qrb-ros-audio-service/qrb-ros-audio-service-msgs_0.2.0.bb
@@ -1,0 +1,53 @@
+inherit ros_distro_${ROS_DISTRO}
+inherit ros_component
+
+DESCRIPTION = "QRB ROS Audio Service msgs"
+AUTHOR           = "Ronghui Zhu <ronghuiz@qti.qualcomm.com>"
+ROS_AUTHOR       = "Ronghui Zhu"
+SECTION          = "devel"
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://../../LICENSE;md5=86fcc2294062130b497ba0ffff9f82fc"
+
+ROS_CN = "qrb_ros_audio_service_msgs"
+ROS_BPN = "qrb_ros_audio_service_msgs"
+
+ROS_BUILD_DEPENDS = " \
+    std-msgs \
+    action-msgs \
+    rosidl-default-generators-native \
+"
+
+ROS_BUILDTOOL_DEPENDS = " \
+    ament-cmake-auto-native \
+    rosidl-default-generators-native \
+"
+
+ROS_EXEC_DEPENDS = " \
+    builtin-interfaces \
+    rosidl-default-runtime \
+    std-msgs \
+    rcl-interfaces \
+"
+
+ROS_EXPORT_DEPENDS = " \
+    std-msgs \
+    action-msgs \
+    rosidl-default-generators-native \
+"
+
+ROS_BUILDTOOL_EXPORT_DEPENDS = ""
+
+DEPENDS = "${ROS_BUILD_DEPENDS} ${ROS_BUILDTOOL_DEPENDS}"
+DEPENDS += "${ROS_EXPORT_DEPENDS} ${ROS_BUILDTOOL_EXPORT_DEPENDS}"
+
+RDEPENDS:${PN} += "${ROS_EXEC_DEPENDS}"
+
+SRC_URI = "git://github.com/qualcomm-qrb-ros/qrb_ros_interfaces.git;protocol=https;branch=stable/0.2.0"
+SRCREV = "58afc211200aee777d16ce9b9e916f645de44190"
+S = "${UNPACKDIR}/${BP}/qrb_ros_audio_service_msgs/qrb_ros_audio_service_msgs"
+
+ROS_BUILD_TYPE = "ament_cmake"
+
+inherit ros_${ROS_BUILD_TYPE}
+
+inherit robotics-package

--- a/recipes/qrb-ros-audio-service/qrb-ros-audio-service_1.0.3.bb
+++ b/recipes/qrb-ros-audio-service/qrb-ros-audio-service_1.0.3.bb
@@ -1,0 +1,55 @@
+inherit ros_distro_${ROS_DISTRO}
+inherit ros_component
+inherit ros_insane_dev_so
+inherit pkgconfig
+
+DESCRIPTION = "QRB ROS Audio Service"
+AUTHOR = "Ronghui Zhu <ronghuiz@qti.qualcomm.com>"
+ROS_AUTHOR = "Ronghui Zhu"
+SECTION = "devel"
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://../LICENSE;md5=68c28a8a26024c85c589d0de638520b6"
+
+ROS_CN = "qrb_ros_audio_service"
+ROS_BPN = "qrb_ros_audio_service"
+
+ROS_BUILD_DEPENDS = " \
+    rclcpp \
+    rclcpp-components \
+    rclcpp-action \
+    qrb-audio-service-lib \
+    qrb-ros-audio-service-msgs \
+    qrb-ros-audio-common \
+"
+
+ROS_BUILDTOOL_DEPENDS = " \
+    ament-cmake-auto-native \
+    rosidl-default-generators-native \
+"
+
+ROS_EXPORT_DEPENDS = ""
+
+ROS_BUILDTOOL_EXPORT_DEPENDS = ""
+
+ROS_EXEC_DEPENDS = " \
+    rclcpp \
+    qrb-audio-service-lib \
+    qrb-ros-audio-service-msgs \
+    qrb-ros-audio-common \
+"
+
+DEPENDS = "${ROS_BUILD_DEPENDS} ${ROS_BUILDTOOL_DEPENDS}"
+DEPENDS += "${ROS_EXPORT_DEPENDS} ${ROS_BUILDTOOL_EXPORT_DEPENDS}"
+
+RDEPENDS:${PN} += "${ROS_EXEC_DEPENDS}"
+
+SRC_URI = "git://github.com/quic-qrb-ros/qrb_ros_audio_service.git;protocol=https;branch=stable/1.0.3"
+SRCREV = "7a6e720cbd0a649432461a41069e880647c5c2be"
+S = "${UNPACKDIR}/${BP}/qrb_ros_audio_service"
+PV = "1.0.3"
+
+ROS_BUILD_TYPE = "ament_cmake"
+
+inherit ros_${ROS_BUILD_TYPE}
+
+inherit robotics-package


### PR DESCRIPTION
CRs-Fixed: 4511107

Motivation
This PR adds the qrb_ros_audio_service to the build system. The goal is to allow the qrb_ros_audio_service to be built independently with proper build system support, making its integration more modular and aligned with existing build workflows.
Impact
After this change, the qrb_ros_audio_service can be enabled and compiled as a standalone component through the build system