### PR TITLE
feat: add apriltag pipeline sample

### DIFF
--- a/recipes-bbappends/recipe-ros/apriltag-ros/apriltag-ros_3.3.0-1.bbappend
+++ b/recipes-bbappends/recipe-ros/apriltag-ros/apriltag-ros_3.3.0-1.bbappend
@@ -1,0 +1,3 @@
+CXXFLAGS:append = " -Wno-error=deprecated-declarations"
+
+RDEPENDS:${PN}:remove = "camera-ros"

--- a/recipes-bbappends/recipe-ros/apriltag/apriltag_3.4.5-1.bbappend
+++ b/recipes-bbappends/recipe-ros/apriltag/apriltag_3.4.5-1.bbappend
@@ -1,0 +1,7 @@
+SRC_URI:remove = "file://0001-CMakeLists.txt-allow-to-set-PY_DEST.patch"
+
+do_configure:append() {
+    if [ -f ${B}/build.ninja ]; then
+        sed -i -e 's/-Werror[^ ]*//g' ${B}/build.ninja
+    fi
+}

--- a/recipes-products/packagegroups/packagegroup-oss-with-prop-deps.bb
+++ b/recipes-products/packagegroups/packagegroup-oss-with-prop-deps.bb
@@ -30,6 +30,7 @@ QRB_ROS_SAMPLE = " \
     sample-object-detection \
     sample-object-segmentation \
     sample-resnet101 \
+    sample-apriltag \
 "
 
 # If you do not work within the above two organizations and are preparing to merge your code into the Qualcomm Linux Intelligence Robotics Image, 

--- a/recipes/qrb-ros-samples/sample-apriltag_1.0.0.bb
+++ b/recipes/qrb-ros-samples/sample-apriltag_1.0.0.bb
@@ -1,0 +1,35 @@
+ROS_BUILD_TYPE = "ament_cmake"
+
+ROS_CN = "sample_apriltag"
+ROS_BPN = "sample_apriltag"
+
+SRC_URI = "git://github.com/qualcomm-qrb-ros/qrb_ros_samples.git;protocol=https;branch=stable-sample_apriltag/1.0.0"
+SRCREV = "8437e7458d8c50a49a2f12627a5c3c4f7d0bb52a"
+
+ROS_BUILD_DEPENDS = " \
+"
+
+ROS_BUILDTOOL_DEPENDS = " \
+    ament-cmake-auto-native \
+"
+
+ROS_EXPORT_DEPENDS = " \
+"
+
+ROS_EXEC_DEPENDS = " \
+    image-proc \
+    rclcpp-components \
+    qrb-ros-camera \
+    qrb-ros-colorspace-convert \
+    apriltag-ros \
+"
+
+ROS_TEST_DEPENDS = " \
+    ament-lint-auto \
+    ament-lint-common \
+"
+
+DEPENDS = "${ROS_BUILD_DEPENDS} ${ROS_BUILDTOOL_DEPENDS} ${ROS_EXPORT_DEPENDS} ${ROS_TEST_DEPENDS}"
+RDEPENDS:${PN} += "${ROS_EXEC_DEPENDS}"
+
+require include/qrb-ros-samples.inc


### PR DESCRIPTION
CRs-Fixed: 4435584

Motivation:
Add an AprilTag pipeline sample ROS package that includes launch scripts and configurations for demonstrating AprilTag detection capabilities.

Impact:
Enable Apriltag pipeline samples in robotics images.
