### PR TITLE
feat: enable qrb ros yolo process feature

### DIFF
--- a/recipes-products/packagegroups/packagegroup-robotics-opensource.bb
+++ b/recipes-products/packagegroups/packagegroup-robotics-opensource.bb
@@ -43,6 +43,8 @@ QUALCOMM_QRB_ROS = " \
     qrb-ros-amr \
     qrb-ros-follow-path \
     qrb-ros-nn-inference \
+    qrb-ros-cv-tensor-common-process \
+    qrb-ros-yolo-process \
 "
 
 # If it is qrb ros sample, Please place all of them under this variable.

--- a/recipes/qrb-ros-tensor-process/qrb-ros-cv-tensor-common-process_1.1.0.bb
+++ b/recipes/qrb-ros-tensor-process/qrb-ros-cv-tensor-common-process_1.1.0.bb
@@ -1,0 +1,65 @@
+inherit ros_distro_${ROS_DISTRO}
+inherit ros_component
+
+ROS_BUILD_TYPE = "ament_cmake"
+
+inherit ros_${ROS_BUILD_TYPE}
+inherit robotics-package
+
+SRC_URI  = "git://github.com/qualcomm-qrb-ros/qrb_ros_tensor_process.git;protocol=https;branch=stable/1.1.0"
+SRCREV   = "6e5d64cda46e38a0b9536c1fe059b29ed97bd8b1"
+S = "${UNPACKDIR}/${BPN}-${PV}/cv_tensor_process/cv_tensor_common_process"
+
+DESCRIPTION = "QRB ROS CV tensor common process node"
+AUTHOR = "Xiao Li <xiaolee@qti.qualcomm.com>"
+ROS_AUTHOR = "Xiao Li"
+SECTION = "devel"
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=65b8cd575e75211d9d4ca8603167da1c"
+
+ROS_CN = "qrb_ros_cv_tensor_common_process"
+ROS_BPN = "qrb_ros_cv_tensor_common_process"
+
+ROS_BUILD_DEPENDS = " \
+    ament-index-cpp \
+    cv-bridge \
+    rclcpp \
+    rclcpp-components \
+    std-msgs \
+    sensor-msgs \
+    qrb-ros-tensor-list-msgs \
+    qrb-ros-transport-image-type \
+    lib-mem-dmabuf \
+"
+
+ROS_BUILDTOOL_DEPENDS = " \
+    ament-cmake-auto-native \
+    ament-cmake-ros-native \
+"
+
+ROS_EXEC_DEPENDS = " \
+    rclcpp \
+    sensor-msgs \
+    qrb-ros-tensor-list-msgs \
+    qrb-ros-transport-image-type \
+    lib-mem-dmabuf \
+    cv-bridge \
+    rclcpp-components \
+"
+
+ROS_EXPORT_DEPENDS = " \
+    rclcpp \
+    ament-index-cpp \
+"
+
+ROS_BUILDTOOL_EXPORT_DEPENDS = " \
+"
+
+ROS_TEST_DEPENDS = " \
+"
+
+DEPENDS = "${ROS_BUILD_DEPENDS} ${ROS_BUILDTOOL_DEPENDS}"
+DEPENDS += "${ROS_EXPORT_DEPENDS} ${ROS_BUILDTOOL_EXPORT_DEPENDS} ${ROS_TEST_DEPENDS}"
+
+
+RDEPENDS:${PN} = "${ROS_EXEC_DEPENDS}"

--- a/recipes/qrb-ros-tensor-process/qrb-ros-vision-msgs_0.2.0.bb
+++ b/recipes/qrb-ros-tensor-process/qrb-ros-vision-msgs_0.2.0.bb
@@ -1,0 +1,42 @@
+inherit ros_distro_${ROS_DISTRO}
+inherit ros_component
+
+ROS_BUILD_TYPE = "ament_cmake"
+
+inherit ros_${ROS_BUILD_TYPE}
+inherit robotics-package
+
+SRC_URI = "git://github.com/qualcomm-qrb-ros/qrb_ros_interfaces.git;protocol=https;branch=stable/0.2.0"
+SRCREV = "58afc211200aee777d16ce9b9e916f645de44190"
+S = "${UNPACKDIR}/${BPN}-${PV}/qrb_ros_vision_msgs"
+
+DESCRIPTION = "QRB ROS vision messages"
+AUTHOR = "Xiao Li <xiaolee@qti.qualcomm.com>"
+ROS_AUTHOR = "Xiao Li"
+SECTION = "devel"
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://../LICENSE;md5=86fcc2294062130b497ba0ffff9f82fc"
+
+ROS_CN = "qrb_ros_vision_msgs"
+ROS_BPN = "qrb_ros_vision_msgs"
+
+ROS_BUILD_DEPENDS = " \
+    std-msgs \
+    sensor-msgs \
+    vision-msgs \
+"
+ROS_BUILDTOOL_DEPENDS = " \
+    ament-cmake-auto-native \
+    ament-cmake-ros-native \
+    rosidl-default-generators-native \
+"
+ROS_EXPORT_DEPENDS = ""
+ROS_BUILDTOOL_EXPORT_DEPENDS = ""
+ROS_EXEC_DEPENDS = " \
+    std-msgs \
+    sensor-msgs \
+    vision-msgs \
+"
+DEPENDS = "${ROS_BUILD_DEPENDS} ${ROS_BUILDTOOL_DEPENDS}"
+DEPENDS += "${ROS_EXPORT_DEPENDS} ${ROS_BUILDTOOL_EXPORT_DEPENDS}"
+RDEPENDS:${PN} += "${ROS_EXEC_DEPENDS}"

--- a/recipes/qrb-ros-tensor-process/qrb-ros-yolo-process_1.1.0.bb
+++ b/recipes/qrb-ros-tensor-process/qrb-ros-yolo-process_1.1.0.bb
@@ -1,0 +1,70 @@
+inherit ros_distro_${ROS_DISTRO}
+inherit ros_component
+
+ROS_BUILD_TYPE = "ament_cmake"
+
+inherit ros_${ROS_BUILD_TYPE}
+inherit robotics-package
+
+SRC_URI  = "git://github.com/qualcomm-qrb-ros/qrb_ros_tensor_process.git;protocol=https;branch=stable/1.1.0"
+SRCREV   = "6e5d64cda46e38a0b9536c1fe059b29ed97bd8b1"
+S = "${UNPACKDIR}/${BPN}-${PV}/cv_tensor_process/yolo_v8_process/qrb_ros_yolo_process"
+
+DESCRIPTION = "QRB ROS Yolo Pre/Post process node"
+AUTHOR = "Xiao Li <xiaolee@qti.qualcomm.com>"
+ROS_AUTHOR = "Xiao Li"
+SECTION = "devel"
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=65b8cd575e75211d9d4ca8603167da1c"
+
+ROS_CN = "qrb_ros_yolo_process"
+ROS_BPN = "qrb_ros_yolo_process"
+
+ROS_BUILD_DEPENDS = " \
+    ament-index-cpp \
+    cv-bridge \
+    rclcpp \
+    rclcpp-components \
+    qrb-yolo-process-lib \
+    message-filters \
+    std-msgs \
+    sensor-msgs \
+    vision-msgs \
+    qrb-ros-vision-msgs \
+    qrb-ros-tensor-list-msgs \
+"
+
+ROS_BUILDTOOL_DEPENDS = " \
+    ament-cmake-auto-native \
+    ament-cmake-ros-native \
+"
+
+ROS_EXEC_DEPENDS = " \
+    rclcpp \
+    sensor-msgs \
+    vision-msgs \
+    message-filters \
+    cv-bridge \
+    rclcpp-components \
+    qrb-ros-vision-msgs \
+    qrb-ros-tensor-list-msgs \
+    qrb-yolo-process-lib \
+"
+
+ROS_EXPORT_DEPENDS = " \
+    rclcpp \
+    ament-index-cpp \
+"
+
+ROS_BUILDTOOL_EXPORT_DEPENDS = " \
+"
+
+ROS_TEST_DEPENDS = " \
+"
+
+DEPENDS = "${ROS_BUILD_DEPENDS} ${ROS_BUILDTOOL_DEPENDS}"
+DEPENDS += "${ROS_EXPORT_DEPENDS} ${ROS_BUILDTOOL_EXPORT_DEPENDS} ${ROS_TEST_DEPENDS}"
+
+
+RDEPENDS:${PN} = "${ROS_EXEC_DEPENDS}"
+

--- a/recipes/qrb-ros-tensor-process/qrb-yolo-process-lib_1.1.0.bb
+++ b/recipes/qrb-ros-tensor-process/qrb-yolo-process-lib_1.1.0.bb
@@ -1,0 +1,49 @@
+inherit ros_distro_${ROS_DISTRO}
+inherit ros_component
+
+ROS_BUILD_TYPE = "ament_cmake"
+
+inherit ros_${ROS_BUILD_TYPE}
+inherit robotics-package
+
+SRC_URI  = "git://github.com/qualcomm-qrb-ros/qrb_ros_tensor_process.git;protocol=https;branch=stable/1.1.0"
+SRCREV   = "6e5d64cda46e38a0b9536c1fe059b29ed97bd8b1"
+S = "${UNPACKDIR}/${BPN}-${PV}/cv_tensor_process/yolo_v8_process/qrb_yolo_process_lib"
+
+DESCRIPTION = "QRB ROS Yolo process library"
+AUTHOR = "Xiao Li <xiaolee@qti.qualcomm.com>"
+ROS_AUTHOR = "Xiao Li"
+SECTION = "devel"
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=65b8cd575e75211d9d4ca8603167da1c"
+
+ROS_CN = "qrb_yolo_process_lib"
+ROS_BPN = "qrb_yolo_process_lib"
+
+ROS_BUILD_DEPENDS = " \
+    yaml-cpp \
+    opencv \
+"
+
+ROS_BUILDTOOL_DEPENDS = " \
+    ament-cmake-auto-native \
+"
+
+ROS_EXEC_DEPENDS = " \
+    yaml-cpp \
+    opencv \
+"
+
+ROS_EXPORT_DEPENDS = " \
+"
+
+ROS_BUILDTOOL_EXPORT_DEPENDS = " \
+"
+
+ROS_TEST_DEPENDS = " \
+"
+
+DEPENDS = "${ROS_BUILD_DEPENDS} ${ROS_BUILDTOOL_DEPENDS}"
+DEPENDS += "${ROS_EXPORT_DEPENDS} ${ROS_BUILDTOOL_EXPORT_DEPENDS} ${ROS_TEST_DEPENDS}"
+
+RDEPENDS:${PN} = "${ROS_EXEC_DEPENDS}"


### PR DESCRIPTION
CRs-Fixed: 4512655
 
Motivation:
Add support for qrb ros yolo process feature on the mainline0.0 platform.
 
Impact:
The qrb ros yolo process ros nodes will be installed to /opt/ros/jazzy/lib and package to qirp sdk.