### PR TITLE
fix: update sample source SRCREV

### DIFF
--- a/recipes/qrb-ros-samples/sample-resnet101_1.0.1.bb
+++ b/recipes/qrb-ros-samples/sample-resnet101_1.0.1.bb
@@ -5,7 +5,7 @@ ROS_BPN = "sample_resnet101"
 
 SRC_URI = "git://github.com/qualcomm-qrb-ros/qrb_ros_samples.git;protocol=https;branch=stable-sample_resnet101/1.0.1"
 
-SRCREV = "737c43783991977b97fb7e376e1257b0c2dbfcb6"
+SRCREV = "08aba6c417703a8906b039fc7e33183eb19688c1"
 
 
 ROS_BUILD_DEPENDS = " \

--- a/recipes/qrb-ros-samples/sample-resnet101_1.0.1.bb
+++ b/recipes/qrb-ros-samples/sample-resnet101_1.0.1.bb
@@ -3,7 +3,10 @@ ROS_BUILD_TYPE = "ament_python"
 ROS_CN = "sample_resnet101"
 ROS_BPN = "sample_resnet101"
 
-S = "${WORKDIR}/git/ai_vision/${ROS_CN}"
+SRC_URI = "git://github.com/qualcomm-qrb-ros/qrb_ros_samples.git;protocol=https;branch=stable-sample_resnet101/1.0.1"
+
+SRCREV = "737c43783991977b97fb7e376e1257b0c2dbfcb6"
+
 
 ROS_BUILD_DEPENDS = " \
 "


### PR DESCRIPTION
CRs-Fixed:  4514723

Motivation:
The original model label link is no longer valid and has been replaced with a new link, 
so need to update the source SRCREV.

Impact:
The sample will include the new model label link.
