### PR TITLE
fix: update ImageNet label download link in qirp-setup.sh

### DIFF
--- a/recipes-sdk/files/qirp-setup.sh
+++ b/recipes-sdk/files/qirp-setup.sh
@@ -19,7 +19,7 @@ ai_model_list=(
     MediaPipeHandLandmarkDetector.bin,https://huggingface.co/qualcomm/MediaPipe-Hand-Detection/resolve/7c266a43cf0328c5e00c96007a339ae41ddffa65/MediaPipeHandLandmarkDetector.bin?download=true
     anchors_palm.npy,https://raw.githubusercontent.com/zmurez/MediaPipePyTorch/65f2549ba35cd61dfd29f402f6c21882a32fabb1/anchors_palm.npy
     ResNet101_w8a8.bin,https://huggingface.co/qualcomm/ResNet101/resolve/121564046ebb2353d4a0aa67bf89c11e0c8e80d9/ResNet101_w8a8.bin?download=true
-    imagenet_labels.txt,https://raw.githubusercontent.com/quic/ai-hub-models/refs/heads/main/qai_hub_models/labels/imagenet_labels.txt
+    imagenet_labels.txt,https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt
     HRNetPose.bin,https://huggingface.co/qualcomm/HRNetPose/resolve/6011b6e69a84dad8f53fb555b11035a5e26c8755/HRNetPose.bin?download=true
     MediaPipeFaceDetector.bin,https://huggingface.co/qualcomm/MediaPipe-Face-Detection/resolve/0dd669a326ec24a884e51b82741997299d937705/MediaPipeFaceDetector.bin
     MediaPipeFaceLandmarkDetector.bin,https://huggingface.co/qualcomm/MediaPipe-Face-Detection/resolve/0dd669a326ec24a884e51b82741997299d937705/MediaPipeFaceLandmarkDetector.bin


### PR DESCRIPTION
CRs-Fixed:4526297

Motivation:
The original link is outdated; update the label link in the ResNet101 sample

Impact:
Sample will download with new label link, not impact original function