### PR TITLE
ci: add workflow dispatch trigger in nightly-build-wrynose.yml

### DIFF
--- a/.github/workflows/nightly-build-wrynose.yml
+++ b/.github/workflows/nightly-build-wrynose.yml
@@ -7,6 +7,13 @@ on:
   # At 23:22 UTC everyday - picked a random "minute" as top of hour can be busy in github
   - cron: "00 12 * * *"   # daily job - pick a random "minute"  - top of hour can be busy in github
 
+  workflow_dispatch:
+    inputs:
+      use_sstate:
+        description: "Use SSTATE cache"
+        required: false
+        default: "true"
+
 permissions:
   checks: write
   pull-requests: write


### PR DESCRIPTION
CRs-Fixed: 4527239

Motivation:
- Add workflow_dispatch trigger in nightly-build-wrynose.yml to manually trigger nightly builds on the wrynose branch.

Impact:
- A dispatch trigger button will appear on the GitHub Actions webpage, allowing manual invocation of the workflow.