### PR TITLE
chore: update dependent layer revisions to wrynose branch

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -1,4 +1,5 @@
-name: Nightly Build (main)
+name: Nightly Build
+run-name: "Nightly Build (${{ github.ref_name }})"
 
 on:
   schedule:
@@ -11,7 +12,7 @@ on:
       use_sstate:
         description: "Use SSTATE cache"
         required: false
-        default: "false"
+        default: "true"
 
 permissions:
   checks: write

--- a/ci/qcom-robotics-distro.yml
+++ b/ci/qcom-robotics-distro.yml
@@ -2,12 +2,16 @@ header:
   version: 14
   includes:
   - ci/qcom-distro.yml
+
+defaults:
+  repos:
+    branch: wrynose
+
 repos:
   meta-qcom-robotics-sdk:
-    branch: main
+    branch: wrynose
   meta-qcom:
     url: https://github.com/qualcomm-linux/meta-qcom
-    commit: c31b161fc1f9ad63c85ffaf4a0b7b41a8a3aee9b
   oe-core:
     url: https://github.com/openembedded/openembedded-core
     layers:
@@ -19,13 +23,14 @@ repos:
     commit: 8c008f36d7af1e63cb3f4a2ba763efd1f1e5fe4d
   bitbake:
     url: https://github.com/openembedded/bitbake
+    branch: "2.18"
     layers:
       .: disabled
-    commit: 5d722b5d65e4eef7befe6376983385421e993f86
+    commit: a2dd9be788274d9c7280be5b1be5eb5c3990cf54
   meta-qcom-distro:
+    branch: wrynose
     url: https://github.com/qualcomm-linux/meta-qcom-distro
-    branch: main
-    commit: 5327a4c4154abb72cf3bee1f34f9beecf4e09331
+    commit: 51a70d3dad35d59230974534cd95edbf35b659e2
   meta-openembedded:
     url: https://github.com/openembedded/meta-openembedded
     layers:
@@ -46,11 +51,9 @@ repos:
     branch: master
     commit: 75402c8d1ea1203dcf3a63792161f7d5d93946bb
   meta-selinux:
-    branch: master
     url: https://git.yoctoproject.org/meta-selinux
     commit: 4904b87b12c51a68efc5b9cd45c7b519fdc48af1
   meta-updater:
-    branch: master
     url: https://github.com/uptane/meta-updater
     commit: d713c99a9ddace090c0efc0ed57022185daa6fb2
   meta-security:
@@ -84,7 +87,7 @@ repos:
 local_conf_header:
   resource_limitation: '# Capture the count of cpu cores available from the host.
 
-    CPU_COUNT = "${@oe.utils.cpu_count(at_least=2, at_most=9)}"
+    CPU_COUNT = "${@oe.utils.cpu_count(at_least=2, at_most=8)}"
 
 
     # Number of parallel threads make can run based on cpu cores with a max cap at

--- a/recipes-bbappends/recipe-kernel/linux/linux-qcom-next_git.bbappend
+++ b/recipes-bbappends/recipe-kernel/linux/linux-qcom-next_git.bbappend
@@ -1,8 +1,6 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 SRC_URI += "file://configs/robotics-kernel.cfg"
-SRC_URI += "file://0001-arm64-dts-qcom-lemans-evk-enable-UART0-for-robot-exp.patch"
-SRC_URI += "file://0002-arm64-dts-qcom-monaco-evk-enable-UART6-for-robot-exp.patch"
 
 # do_configure:prepend:append() {
 #     #cat ${UNPACKDIR}/configs/robotics-kernel.cfg >> ${UNPACKDIR}/configs/qcom.cfg


### PR DESCRIPTION
CRs-Fixed: 4527239

Motivation:
- Checkout dependent layers to wrynose branch revisions.
- Speed up the nightly build process on the wrynose branch by reusing shared sstate cache.

Impact:
- Dependent layer revisions will point to the wrynose branch.
- The `use_sstate` flag is set to `true`, significantly reducing build time for subsequent nightly runs.