### PR TITLE
fix: add apriltag sample to qir sdk artifact

### DIFF
--- a/recipes-sdk/files/content_config.json
+++ b/recipes-sdk/files/content_config.json
@@ -36,7 +36,11 @@
             "name": "simulation-sample-amr-simple-motion",
             "to": "qirp-samples/robotics"
         },
-	      {
+        {
+            "name": "sample-apriltag",
+            "to": "qirp-samples/robotics"
+        },
+        {
             "name": "sample-hand-detection",
             "to": "qirp-samples/ai_vision"
         },


### PR DESCRIPTION
CRs-Fixed: 4529513

Motivation:
- Enable AprilTag pipeline sample code in QIR SDK artifact.

Impact:
- QIR SDK artifact will include AprilTag pipeline sample code.
