### PR TITLE
fix: correct shell syntax in rdepends-collector.bbclass, rootfs-symlink.bbclass, psdk-image.bbclass

### DIFF
--- a/classes/psdk-image.bbclass
+++ b/classes/psdk-image.bbclass
@@ -20,15 +20,14 @@
 #
 TOOLCHAIN_PATH = "${DEPLOY_DIR}/sdk"
 SDK_PN = "qirp-sdk"
-SDK_VERSION = "2.4.0"
-OSS_CHANNEL_FLAG = "${@bb.utils.contains_any('BBFILE_COLLECTIONS', 'qcom-robotics-extras', 'false', 'true', d)}"
+SDK_VERSION ?= "2.4.0"
 
 # Collect the standard SDK toolchain and copy it into the SDK's toolchain/
 # directory. If no matching toolchain is found, the task only emits a warning.
 # Function: process_toolchain
 process_toolchain() {
     bbnote "Processing toolchain..."
-    if ls ${TOOLCHAIN_PATH}/* | xargs -n1 basename | grep ${TOOLCHAIN_OUTPUTNAME} >/dev/null 2>&1; then
+    if find "${TOOLCHAIN_PATH}" -maxdepth 1 -name "${TOOLCHAIN_OUTPUTNAME}*" | grep -q .; then
         bbnote "Standard SDK Toolchain found in ${TOOLCHAIN_PATH}, copy to ${QIRP_SSTATE_IN_DIR}/${SDK_PN}/toolchain/"
         install -d ${QIRP_SSTATE_IN_DIR}/${SDK_PN}/toolchain
         find ${TOOLCHAIN_PATH} -type f -name "${TOOLCHAIN_OUTPUTNAME}*" -exec cp {} ${QIRP_SSTATE_IN_DIR}/${SDK_PN}/toolchain/ \;
@@ -74,7 +73,6 @@ process_qir_samples() {
         bbnote "  Processing sample: $name"
         bbnote "  Target directory: $to_dir"
         
-        # mkdir ${to_dir}
         install -d "${to_dir}"
         
         # Copy ${source_dir} to ${to_dir}
@@ -105,7 +103,7 @@ process_qir_samples() {
 
     # Process sample.json
     SAMPLE_JSON="${ROBIOTICS_LAYER_DIR}/recipes-sdk/files/samples.json"
-    if [ -n "$SAMPLE_JSON" ] && [ -f "$SAMPLE_JSON" ]; then
+    if [ -f "$SAMPLE_JSON" ]; then
         # Ensure target directory exists
         install -d ${QIRP_SSTATE_IN_DIR}/${SDK_PN}/qirp-samples/
         cp "$SAMPLE_JSON" ${QIRP_SSTATE_IN_DIR}/${SDK_PN}/qirp-samples/

--- a/classes/rdepends-collector.bbclass
+++ b/classes/rdepends-collector.bbclass
@@ -33,14 +33,13 @@ python do_collect_rdepends() {
     """
     import os
     
-    d = d  # bitbake data object
     pn = d.getVar("PN")
     
     bb.note("Collecting RDEPENDS for packagegroup: {}".format(pn))
     
     # Get RDEPENDS
     rdepends_var = 'RDEPENDS:{}'.format(pn)
-    rdepends = d.getVar(rdepends_var, True) or ""
+    rdepends = d.getVar(rdepends_var) or ""
     
     if not rdepends:
         bb.warn("RDEPENDS for {} is empty (will be added later)".format(pn))

--- a/classes/rootfs-symlink.bbclass
+++ b/classes/rootfs-symlink.bbclass
@@ -35,7 +35,7 @@ python do_rootfs_create_symlinks () {
     pairs = pairs.split()
 
     if not pairs:
-        bb.note("rootfs-symlink: ROS_SYMLINK_PAIRS not set, skip")
+        bb.note("rootfs-symlink: ROOTFS_SYMLINK_PAIRS not set, skip")
         return
 
     for p in pairs:
@@ -52,7 +52,7 @@ python do_rootfs_create_symlinks () {
         dest = dest.strip()
 
         if not src or not dest:
-            bb.warn(f"rootfs-symlink: empty SRC/DEST（'{p}', skip")
+            bb.warn(f"rootfs-symlink: empty SRC/DEST ('{p}'), skip")
             continue
 
         abs_dest = os.path.join(dvar, dest.lstrip('/'))
@@ -64,7 +64,7 @@ python do_rootfs_create_symlinks () {
             subprocess.check_call(['ln', '-snf', src, abs_dest])
             bb.note(f"rootfs-symlink: ln -snf {src} -> {abs_dest}")
         except subprocess.CalledProcessError as e:
-            bb.fatal(f"rootfs-symlink: create link fail : {src} -> {abs_dest}, error ：{e}")
+            bb.fatal(f"rootfs-symlink: create link fail: {src} -> {abs_dest}, error: {e}")
 }
 
 # Register the symlink creation task as a rootfs post-processing step so the


### PR DESCRIPTION
CRs-Fixed: 4532394

**Motivation**
Bug fixes for issues identified in rdepends-collector.bbclass/rootfs-symlink.bbclass/psdk-image.bbclass review

**Impact**
- rdepends-collector: No functional change; task output and generated .list files are identical.
- rootfs-symlink: Log messages now accurately reflect the variable name and contain only ASCII; no change to symlink creation behavior.
- psdk-image:
SDK_VERSION default remains 2.4.0; image recipes can now override it without modifying the class.
Toolchain detection is more robust when TOOLCHAIN_PATH is empty or does not yet exist.
All other changes are functionally equivalent; SDK output is unchanged.
- No recipe-level changes required; all fixes are self-contained within their respective classes.