### PR TITLE
chore(ci): update meta-ros to 8f6f2c0d

### DIFF
--- a/.github/workflows/check-meta-ros-update.yml
+++ b/.github/workflows/check-meta-ros-update.yml
@@ -1,0 +1,190 @@
+name: Check meta-ros updates
+
+on:
+  schedule:
+    - cron: "22 10 5 * *"   # monthly - 5th day at 10:22 UTC
+  workflow_dispatch:
+
+jobs:
+  check-and-update:
+    runs-on: ubuntu-24.04
+    # Only run in the fork, not if someone else forks this repo
+    if: github.repository_owner == 'jiaxshi'
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get current meta-ros commit from yml
+        id: current
+        run: |
+          commit=$(python3 - <<'EOF'
+          import re
+          with open('ci/qcom-robotics-distro.yml') as f:
+              lines = f.readlines()
+          in_section = False
+          for line in lines:
+              if re.match(r'^  meta-ros:', line):
+                  in_section = True
+              elif in_section and re.match(r'^  \S', line):
+                  in_section = False
+              if in_section and re.match(r'^    commit:', line):
+                  print(line.split(':', 1)[1].strip())
+                  break
+          EOF
+          )
+          echo "commit=$commit" >> "$GITHUB_OUTPUT"
+
+      - name: Get latest meta-ros commit from upstream master
+        id: latest
+        run: |
+          commit=$(git ls-remote https://github.com/ros/meta-ros.git refs/heads/master refs/heads/main | head -1 | cut -f1)
+          if [ -z "$commit" ]; then
+            echo "ERROR: could not find master or main branch on meta-ros upstream" >&2
+            exit 1
+          fi
+          echo "commit=$commit" >> "$GITHUB_OUTPUT"
+          echo "short=${commit:0:8}" >> "$GITHUB_OUTPUT"
+
+      - name: Check if update is needed
+        id: check
+        run: |
+          if [ "${{ steps.current.outputs.commit }}" = "${{ steps.latest.outputs.commit }}" ]; then
+            echo "needed=false" >> "$GITHUB_OUTPUT"
+            echo "meta-ros is already up to date at ${{ steps.current.outputs.commit }}"
+          else
+            echo "needed=true" >> "$GITHUB_OUTPUT"
+            echo "Update available: ${{ steps.current.outputs.commit }} -> ${{ steps.latest.outputs.commit }}"
+          fi
+
+      - name: Check for existing open PR for this commit
+        if: steps.check.outputs.needed == 'true'
+        id: existing
+        env:
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+        run: |
+          branch="chore/update-meta-ros-${{ steps.latest.outputs.short }}"
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+
+          count=$(gh pr list \
+            --repo qualcomm-linux/meta-qcom-robotics-sdk \
+            --state open \
+            --head "jiaxshi:$branch" \
+            --json number \
+            --jq 'length')
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+
+      - name: Update meta-ros commit in yml
+        if: steps.check.outputs.needed == 'true' && steps.existing.outputs.count == '0'
+        env:
+          NEW_COMMIT: ${{ steps.latest.outputs.commit }}
+        run: |
+          python3 - <<'EOF'
+          import os, re
+
+          path = 'ci/qcom-robotics-distro.yml'
+          new_commit = os.environ['NEW_COMMIT']
+
+          with open(path) as f:
+              lines = f.readlines()
+
+          in_section = False
+          updated = False
+          result = []
+          for line in lines:
+              if re.match(r'^  meta-ros:', line):
+                  in_section = True
+              elif in_section and re.match(r'^  \S', line):
+                  in_section = False
+              if in_section and not updated and re.match(r'^    commit:', line):
+                  line = f'    commit: {new_commit}\n'
+                  updated = True
+              result.append(line)
+
+          if not updated:
+              raise SystemExit('ERROR: meta-ros commit line not found in yml')
+
+          with open(path, 'w') as f:
+              f.writelines(result)
+
+          print(f'Updated meta-ros commit to {new_commit}')
+          EOF
+
+      - name: Commit and push update branch
+        if: steps.check.outputs.needed == 'true' && steps.existing.outputs.count == '0'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          OLD="${{ steps.current.outputs.commit }}"
+          NEW="${{ steps.latest.outputs.commit }}"
+          SHORT="${{ steps.latest.outputs.short }}"
+          BRANCH="${{ steps.existing.outputs.branch }}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+
+          {
+            echo "chore(ci): update meta-ros to $SHORT"
+            echo ""
+            echo "Motivation: meta-ros upstream has new commits on the master branch."
+            echo "Previous commit: $OLD"
+            echo "New commit: $NEW"
+            echo ""
+            echo "Impact: Pulls in upstream meta-ros changes. Patch compatibility has not"
+            echo "been verified automatically; manual review is required."
+            echo ""
+            echo "TODO: Verify that the following patches still apply cleanly:"
+            PATCHES=$(find patches -name '*.patch' -type f 2>/dev/null | sort)
+            if [ -n "$PATCHES" ]; then
+              echo "$PATCHES" | sed 's/^/- /'
+            else
+              echo "- (no patches found)"
+            fi
+          } > /tmp/commit-msg.txt
+
+          git add ci/qcom-robotics-distro.yml
+          git commit -F /tmp/commit-msg.txt
+          git push origin "$BRANCH"
+
+      - name: Create pull request to upstream
+        if: steps.check.outputs.needed == 'true' && steps.existing.outputs.count == '0'
+        env:
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+        run: |
+          OLD="${{ steps.current.outputs.commit }}"
+          NEW="${{ steps.latest.outputs.commit }}"
+          SHORT="${{ steps.latest.outputs.short }}"
+          BRANCH="${{ steps.existing.outputs.branch }}"
+
+          {
+            printf '## Summary\n\n'
+            printf 'Update `meta-ros` commit hash to the latest upstream `master`.\n\n'
+            printf '| | Commit |\n|---|---|\n'
+            printf '| **Previous** | `%s` |\n' "$OLD"
+            printf '| **New** | `%s` |\n\n' "$NEW"
+            printf '## Motivation\n\n'
+            printf 'meta-ros upstream has new commits on the master branch. This update\n'
+            printf 'pulls in the latest upstream changes.\n\n'
+            printf '## Impact\n\n'
+            printf 'Pulls in upstream meta-ros changes. Patch compatibility has not been\n'
+            printf 'verified automatically; manual review is required.\n\n'
+            printf '## TODO\n\n'
+            printf '- [ ] Verify that the following patches still apply cleanly:\n'
+            PATCHES=$(find patches -name '*.patch' -type f 2>/dev/null | sort)
+            if [ -n "$PATCHES" ]; then
+              echo "$PATCHES" | while IFS= read -r patch; do
+                printf '  - `%s`\n' "$patch"
+              done
+            else
+              printf '  - (no patches found)\n'
+            fi
+          } > /tmp/pr-body.md
+
+          gh pr create \
+            --repo qualcomm-linux/meta-qcom-robotics-sdk \
+            --head "jiaxshi:$BRANCH" \
+            --base main \
+            --title "chore(ci): update meta-ros to $SHORT" \
+            --body-file /tmp/pr-body.md

--- a/.github/workflows/check-meta-ros-update.yml
+++ b/.github/workflows/check-meta-ros-update.yml
@@ -142,7 +142,9 @@ jobs:
 
           git add ci/qcom-robotics-distro.yml
           git commit -F /tmp/commit-msg.txt
-          git push origin "$BRANCH"
+          # Force-push: remote may have a stale branch from a prior run whose PR
+          # was closed without merging; this branch is bot-managed so forcing is safe.
+          git push origin "$BRANCH" --force
 
       - name: Create pull request to upstream
         if: steps.check.outputs.needed == 'true' && steps.existing.outputs.count == '0'

--- a/.github/workflows/check-meta-ros-update.yml
+++ b/.github/workflows/check-meta-ros-update.yml
@@ -167,14 +167,14 @@ jobs:
             printf 'Pulls in upstream meta-ros changes. Patch compatibility has not been\n'
             printf 'verified automatically; manual review is required.\n\n'
             printf '## TODO\n\n'
-            printf '- [ ] Verify that the following patches still apply cleanly:\n'
+            printf '%s\n' '- [ ] Verify that the following patches still apply cleanly:'
             PATCHES=$(find patches -name '*.patch' -type f 2>/dev/null | sort)
             if [ -n "$PATCHES" ]; then
               echo "$PATCHES" | while IFS= read -r patch; do
                 printf '  - `%s`\n' "$patch"
               done
             else
-              printf '  - (no patches found)\n'
+              printf '%s\n' '  - (no patches found)'
             fi
           } > /tmp/pr-body.md
 

--- a/.github/workflows/check-meta-ros-update.yml
+++ b/.github/workflows/check-meta-ros-update.yml
@@ -61,18 +61,14 @@ jobs:
       - name: Check for existing open PR for this commit
         if: steps.check.outputs.needed == 'true'
         id: existing
-        env:
-          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
         run: |
           branch="chore/update-meta-ros-${{ steps.latest.outputs.short }}"
           echo "branch=$branch" >> "$GITHUB_OUTPUT"
 
-          count=$(gh pr list \
-            --repo qualcomm-linux/meta-qcom-robotics-sdk \
-            --state open \
-            --head "jiaxshi:$branch" \
-            --json number \
-            --jq 'length')
+          # Use unauthenticated REST API to avoid SAML SSO requirement on qualcomm-linux org
+          count=$(curl -s \
+            "https://api.github.com/repos/qualcomm-linux/meta-qcom-robotics-sdk/pulls?state=open&head=jiaxshi:${branch}&per_page=1" \
+            | python3 -c "import sys,json; print(len(json.load(sys.stdin)))")
           echo "count=$count" >> "$GITHUB_OUTPUT"
 
       - name: Update meta-ros commit in yml

--- a/ci/qcom-robotics-distro.yml
+++ b/ci/qcom-robotics-distro.yml
@@ -80,7 +80,7 @@ repos:
       ament_cmake_py_fix:
         repo: meta-qcom-robotics-sdk
         path: patches/0001-ros2-ament_cmake-add-python-configurations-for-class.patch
-    commit: eae6fa810b457c512861efa0d826abab707fa642
+    commit: 8f6f2c0db06275bc851c01a28daed806adab3a26
 local_conf_header:
   resource_limitation: '# Capture the count of cpu cores available from the host.
 


### PR DESCRIPTION
## Summary

Update `meta-ros` commit hash to the latest upstream `master`.

| | Commit |
|---|---|
| **Previous** | `eae6fa810b457c512861efa0d826abab707fa642` |
| **New** | `8f6f2c0db06275bc851c01a28daed806adab3a26` |

## Motivation

meta-ros upstream has new commits on the master branch. This update
pulls in the latest upstream changes.

## Impact

Pulls in upstream meta-ros changes. Patch compatibility has not been
verified automatically; manual review is required.

## TODO

- [ ] Verify that the following patches still apply cleanly:
  - `patches/0001-fix-Update-LAYERSERIES_COMPAT-to-adapt-to-upstream-u.patch`
  - `patches/0001-jazzy-remove-outdated-bbappend-and-patches-of-stomp.patch`
  - `patches/0001-ros2-ament_cmake-add-python-configurations-for-class.patch`
  - `patches/0002-jazzy-update-libdir-of-ompl.patch`
  - `patches/0003-jazzy-move-some-nav2-and-moveit-packages-out-of-blac.patch`
  - `patches/Initial-commit-of-license.patch`
