### PR TITLE
fix: correct SDK_VERSION to hard assignment

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -49,7 +49,7 @@ jobs:
     steps:
       - name: Merge PR
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.SDK_LAYER_TOKEN }}
         run: |
           gh pr merge ${{ github.event.pull_request.number }} \
             --repo ${{ github.repository }} \

--- a/classes/psdk-image.bbclass
+++ b/classes/psdk-image.bbclass
@@ -20,7 +20,7 @@
 #
 TOOLCHAIN_PATH = "${DEPLOY_DIR}/sdk"
 SDK_PN = "qirp-sdk"
-SDK_VERSION ?= "2.4.0"
+SDK_VERSION = "2.4.0"
 
 # Collect the standard SDK toolchain and copy it into the SDK's toolchain/
 # directory. If no matching toolchain is found, the task only emits a warning.


### PR DESCRIPTION
CRs-Fixed: 4540260

Motivation:
- The SDK_VERSION was being resolved dynamically, allowing external environment variables or build flags to override the intended version. This caused incorrect version with meta-qcom-distro configuration.
- Use SDK_LAYER_TOKEN to run auto-merge PR workflow.

Fix:
- Change SDK_VERSION to hard assignment, ensuring the version remains fixed and predictable regardless of build context.

Impact:
- Version string is now stable across all builds.
- No breaking changes to downstream dependencies.
- Build reproducibility improved.