### PR TITLE
ci: correct PAT for PR backporting

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -18,6 +18,6 @@ jobs:
       - name: Create backport pull requests
         uses: korthout/backport-action@7c3f6cd5843cac11bc59a04a1b7699af93261670 # 4.5.0
         with:
-          github_token: ${{ secrets.SDK_LAYER_TOKEN }}
+          github_token: ${{ secrets.QUIC_YOCTO_BACKPORT_PAT }}
           label_pattern: "^backport (wrynose)$"
           branch_name: "backport/${pull_number}-to-${target_branch}"


### PR DESCRIPTION
CRs-Fixed: 4527239

Motivation:
- The SDK_LAYER_TOKEN encountered a permission error, update to QUIC_YOCTO_BACKPORT_PAT to ensure normal operation.

Impact:
- backport and PR workflow will running with QUIC_YOCTO_BACKPORT_PAT for porting merged PR from main to wrynose branch.