### PR TITLE
ci: update robotics-sdk build matrix to align with meta-qcom

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -107,10 +107,12 @@ jobs:
         distro:
           - name: qcom-robotics-distro
             yamlfile: ':ci/qcom-robotics-distro.yml'
-          - name: qcom-robotics-distro-sota
-            yamlfile: ':ci/qcom-robotics-distro-sota.yml'
-          - name: qcom-robotics-distro-selinux
-            yamlfile: ':ci/qcom-robotics-distro-selinux.yml'
+          - name: qcom-robotics-distro-catchall
+            yamlfile: ':ci/qcom-robotics-distro-catchall.yml'
+          - name: debug
+            yamlfile: ':ci/qcom-robotics-distro-catchall.yml:ci/debug.yml'
+          - name: performance
+            yamlfile: ':ci/qcom-robotics-distro-catchall.yml:ci/performance.yml'
         target:
           - type: '_base'
             name: qcom-robotics-image

--- a/ci/debug.yml
+++ b/ci/debug.yml
@@ -1,0 +1,12 @@
+header:
+  version: 14
+
+local_conf_header:
+  debug-build: |
+    DEBUG_BUILD = "1"
+    IMAGE_GEN_DEBUGFS = "1"
+    IMAGE_FSTYPES_DEBUGFS = "tar.bz2"
+
+  cmdline: |
+    KERNEL_CMDLINE_EXTRA_FTRACE = "ftrace=tracing_on trace_buf_size=5M trace_event=timer:timer_expire_entry,timer:timer_expire_exit,timer:hrtimer_cancel,timer:hrtimer_expire_entry,timer:hrtimer_expire_exit,timer:hrtimer_init,timer:hrtimer_start,irq:*,workqueue:*,sched:sched_migrate_task,sched:sched_pi_setprio,sched:sched_switch,sched:sched_wakeup,sched:sched_wakeup_new,power:clock_set_rate,power:clock_enable,power:clock_disable,power:cpu_frequency,regulator:*,thermal:thermal_zone_trip,thermal:thermal_temperature,thermal:cdev_update,rpmh:rpmh_send_msg"
+    KERNEL_CMDLINE_EXTRA:append = " ${KERNEL_CMDLINE_EXTRA_FTRACE}"

--- a/ci/performance.yml
+++ b/ci/performance.yml
@@ -1,0 +1,6 @@
+header:
+  version: 14
+
+local_conf_header:
+  cmdline: |
+    KERNEL_CMDLINE_EXTRA:append = " quiet"

--- a/ci/qcom-robotics-distro-catchall.yml
+++ b/ci/qcom-robotics-distro-catchall.yml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/master/kas/schema-kas.json
+
+header:
+  version: 14
+  includes:
+   - ci/qcom-robotics-distro.yml
+
+distro: qcom-distro-catchall
+
+target:
+  - qcom-robotics-image
+  - qcom-robotics-proprietary-image
+  - qcom-robotics-container-orchestration-image

--- a/conf/distro/qcom-robotics-distro-catchall.conf
+++ b/conf/distro/qcom-robotics-distro-catchall.conf
@@ -1,0 +1,10 @@
+# Copyright (c) 2025 Qualcomm Innovation Center, Inc. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+require conf/distro/include/qcom-base.inc
+require conf/distro/include/qcom-robotics-sdk.inc
+
+require conf/distro/qcom-distro-selinux.conf
+require conf/distro/qcom-distro-sota.conf
+require conf/distro/qcom-distro-ros2-jazzy.conf
+

--- a/recipes-products/images/qcom-robotics-container-orchestration-image.bb
+++ b/recipes-products/images/qcom-robotics-container-orchestration-image.bb
@@ -1,0 +1,5 @@
+# Copyright (c) 2025 Qualcomm Innovation Center, Inc. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+require recipes-products/images/qcom-container-orchestration-image.bb
+require qcom-robotics-proprietary-image.bb


### PR DESCRIPTION
CRs-Fixed: 4548114

Motivation:
- Align the robotics-sdk CI build matrix with the latest meta-qcom platform configurations.

Impact:
- Add new distro: `qcom-robotics-distro-catchall` with debug and performance version.
- Add new image target: `qcom-robotics-container-orchestration-image.bb` 
