### PR TITLE
ci(automation): update the commit id from meta-qcom (wrynose): 26346619144

### DIFF
--- a/ci/qcom-robotics-distro.yml
+++ b/ci/qcom-robotics-distro.yml
@@ -10,7 +10,7 @@ repos:
     branch: wrynose
   meta-qcom:
     url: https://github.com/qualcomm-linux/meta-qcom
-    commit: a26a3832f5f803138ab143ec94fcea256bcb8b93
+    commit: 3a0689ca2daa66a926aedc5f18cddbd52be0360f
   oe-core:
     url: https://github.com/openembedded/openembedded-core
     layers:
@@ -29,7 +29,7 @@ repos:
   meta-qcom-distro:
     branch: wrynose
     url: https://github.com/qualcomm-linux/meta-qcom-distro
-    commit: e70ea44ded665bdd9814fd8de8ae8e5bcfac4e30
+    commit: 28d693526c0bd518a2443302e2c870f8844593a4
   meta-openembedded:
     url: https://github.com/openembedded/meta-openembedded
     layers:


### PR DESCRIPTION
CRs-Fixed: 4548114

## Auto-update from meta-qcom Nightly Build (wrynose)

This pull request automatically updates the repository commits from the latest meta-qcom wrynose nightly build.

**Build Details:**
- meta-qcom nightly build url: https://github.com/qualcomm-linux/meta-qcom/actions/runs/26346619144
- Check and download actions url: https://github.com/DotaIsMind/meta-qcom-robotics-sdk/actions/runs/26375082539
- Timestamp: Sun May 24 22:56:25 UTC 2026