### PR TITLE
chore(ci): update meta-ros to 6a9a84fa (main)

### DIFF
--- a/ci/qcom-robotics-distro.yml
+++ b/ci/qcom-robotics-distro.yml
@@ -80,7 +80,7 @@ repos:
       ament_cmake_py_fix:
         repo: meta-qcom-robotics-sdk
         path: patches/0001-ros2-ament_cmake-add-python-configurations-for-class.patch
-    commit: 8f6f2c0db06275bc851c01a28daed806adab3a26
+    commit: 6a9a84fa556f40fbb90395b52a911f6f803fc695
 local_conf_header:
   resource_limitation: '# Capture the count of cpu cores available from the host.
 


### PR DESCRIPTION
## Summary

Update `meta-ros` commit hash to the latest upstream `master` branch.

| | Commit |
|---|---|
| **Previous** | `8f6f2c0db06275bc851c01a28daed806adab3a26` |
| **New** | `6a9a84fa556f40fbb90395b52a911f6f803fc695` |

## Motivation

meta-ros upstream has new commits on the `master` branch. This update
pulls in the latest upstream changes.

## Impact

Pulls in upstream meta-ros changes. Patch compatibility has not been
verified automatically; manual review is required.

## TODO

- [ ] Verify that the following patches still apply cleanly:
  - `patches/0001-fix-Update-LAYERSERIES_COMPAT-to-adapt-to-upstream-u.patch`
  - `patches/0001-jazzy-remove-outdated-bbappend-and-patches-of-stomp.patch`
  - `patches/0001-ros2-ament_cmake-add-python-configurations-for-class.patch`
  - `patches/0002-jazzy-update-libdir-of-ompl.patch`
  - `patches/0003-jazzy-move-some-nav2-and-moveit-packages-out-of-blac.patch`
  - `patches/Initial-commit-of-license.patch`

CRs-Fixed: 4572507