### PR TITLE
fix(sdk): add buildtools-tarball conditional and eSDK fixes

### DIFF
--- a/conf/distro/include/qcom-robotics-sdk.inc
+++ b/conf/distro/include/qcom-robotics-sdk.inc
@@ -37,7 +37,21 @@ ROS_SDK_TARGET_PACKAGES:append = "${@bb.utils.contains('DISTRO_FEATURES', 'ros2-
 
 TOOLCHAIN_TARGET_TASK:remove = "qirp-sdk"
 
-# Add default packages from meta-ros ros-sdk.inc
-TOOLCHAIN_HOST_TASK:append = " ${ROS_SDK_HOST_PACKAGES}"
+# Avoid buildtools-tarball recipe packages the host *.armv8_2a.rpm for do_populate_sdk task
+TOOLCHAIN_TARGET_TASK:append = "${@(' ' + (d.getVar('ROS_SDK_TARGET_PACKAGES') or '')) if d.getVar('PN') != 'buildtools-tarball' else ''}"
 
-TOOLCHAIN_TARGET_TASK:append = " ${ROS_SDK_TARGET_PACKAGES}"
+TOOLCHAIN_HOST_TASK:append = "${@(' ' + (d.getVar('ROS_SDK_HOST_PACKAGES') or '')) if d.getVar('PN') != 'buildtools-tarball' else ''}"
+
+# esdk fix for populate_sdk_ext:
+# 1. BB_SETSCENE_ENFORCE_IGNORE_TASKS: The inner eSDK build uses %:* to allow
+#    all BUILD TARGET tasks to run from scratch, but this expands only to the
+#    specific targets (qcom-robotics-proprietary-image, esp-qcom-image, etc.).
+#    Dependency recipes like packagegroup-robotics-opensource are NOT targets,
+#    so their tasks (e.g. do_collect_rdepends from rdepends-collector.bbclass)
+#    are not covered and fail with "setscene ignore_tasks".
+#    Fix: add *:do_collect_rdepends to allow it to run from scratch.
+BB_SETSCENE_ENFORCE_IGNORE_TASKS:append = " *:do_collect_rdepends"
+# 2. create-spdx: SPDX image tasks have different unihashes in inner build
+#    (due to TMPDIR rename) and trigger do_collect_rdepends via dependency
+#    chain. Disabling create-spdx in the inner build removes these tasks.
+ESDK_CLASS_INHERIT_DISABLE:append = " create-spdx"

--- a/recipes-bbappends/recipe-devtools/expect/expect_%.bbappend
+++ b/recipes-bbappends/recipe-devtools/expect/expect_%.bbappend
@@ -1,0 +1,2 @@
+EXTRA_OECONF:append = " --with-tcl=${STAGING_LIBDIR}/tcl8.6"
+

--- a/recipes-bbappends/recipe-devtools/tcl8/tcl8_%.bbappend
+++ b/recipes-bbappends/recipe-devtools/tcl8/tcl8_%.bbappend
@@ -1,0 +1,28 @@
+SYSROOT_PREPROCESS_FUNCS += "prepare_tcl8_versioned_sysroot_config"
+
+prepare_tcl8_versioned_sysroot_config() {
+    # Create versioned Tcl 8 config path only in sysroot.
+    # This is for recipes such as expect that need Tcl 8 explicitly.
+    install -d ${SYSROOT_DESTDIR}${libdir}/tcl8.6
+
+    if [ -f ${SYSROOT_DESTDIR}${libdir}/tclConfig.sh ]; then
+        cp -a ${SYSROOT_DESTDIR}${libdir}/tclConfig.sh \
+              ${SYSROOT_DESTDIR}${libdir}/tcl8.6/tclConfig.sh
+    fi
+
+    if [ -f ${SYSROOT_DESTDIR}${libdir}/tclooConfig.sh ]; then
+        cp -a ${SYSROOT_DESTDIR}${libdir}/tclooConfig.sh \
+              ${SYSROOT_DESTDIR}${libdir}/tcl8.6/tclooConfig.sh
+    fi
+
+    # Remove generic Tcl config files from tcl8 sysroot to avoid conflicts with tcl.
+    # expect should use ${STAGING_LIBDIR}/tcl8.6.
+    rm -f ${SYSROOT_DESTDIR}/fixmepath
+    rm -f ${SYSROOT_DESTDIR}/fixmepath.cmd
+
+    rm -f ${SYSROOT_DESTDIR}${bindir_crossscripts}/tclConfig.sh
+    rm -f ${SYSROOT_DESTDIR}${bindir_crossscripts}/tclooConfig.sh
+    rm -f ${SYSROOT_DESTDIR}${libdir}/tclConfig.sh
+    rm -f ${SYSROOT_DESTDIR}${libdir}/tclooConfig.sh
+    rm -f ${SYSROOT_DESTDIR}${libdir}/pkgconfig/tcl.pc
+}


### PR DESCRIPTION
CRs-Fixed: 

Motivation:
- The buildtools-tarball recipe was incorrectly packaging host *.armv8_2a.rpm
  files due to ROS_SDK_HOST/TARGET_PACKAGES being appended unconditionally
- eSDK (populate_sdk_ext) builds were failing because:
  * do_collect_rdepends tasks were not covered by BB_SETSCENE_ENFORCE_IGNORE_TASKS
  * create-spdx caused unihash mismatches due to TMPDIR rename in inner builds
- expect recipe could not find Tcl 8 config files, causing build failures

Changes:
- Add conditional PN != 'buildtools-tarball' for ROS_SDK package appends
- Append *:do_collect_rdepends to BB_SETSCENE_ENFORCE_IGNORE_TASKS
- Disable create-spdx in eSDK via ESDK_CLASS_INHERIT_DISABLE:append
- Add expect bbappend with EXTRA_OECONF pointing to tcl8.6
- Add tcl8 bbappend with SYSROOT_PREPROCESS_FUNCS to create versioned
  tcl8.6 sysroot config and remove generic config files

Impact:
- buildtools-tarball no longer includes host architecture RPM packages
- eSDK builds complete successfully without do_collect_rdepends failures
- expect recipe builds correctly with Tcl 8.6 dependency resolution
- No breaking changes to existing SDK or image builds