### PR TITLE
fix(psdk): replace hyphen with underscore for sample destination path

### DIFF
--- a/classes/psdk-image.bbclass
+++ b/classes/psdk-image.bbclass
@@ -68,6 +68,7 @@ process_qir_samples() {
     
     jq -c '.samples[]' $CONFIG_FILE | while read line; do
         name=$(echo $line | jq -r '.name')
+        ros_pkg_name=$(echo $line | jq -r '.name' | tr '-' '_')
         to_dir="${QIRP_SSTATE_IN_DIR}/${SDK_PN}/$(echo $line | jq -r '.to')"
 
         bbnote "  Processing sample: $name"
@@ -78,8 +79,8 @@ process_qir_samples() {
         # Copy ${source_dir} to ${to_dir}
         source_dir="${DEPLOY_DIR}/sample_source_code/${name}"
         if [ -d "${source_dir}" ]; then
-            bbnote "  Copying entire directory ${source_dir} to ${to_dir}/"
-            cp -rf "${source_dir}" "${to_dir}/" 2>/dev/null || bbwarn "Failed to copy ${name}"
+            bbnote "  Copying entire directory ${source_dir} to ${to_dir}/${ros_pkg_name}"
+            cp -rf "${source_dir}" "${to_dir}/${ros_pkg_name}" 2>/dev/null || bbwarn "Failed to copy ${name}"
         else
             bbwarn "  Source directory ${source_dir} does not exist, skipping sample: $name"
         fi

--- a/recipes-products/packagegroups/packagegroup-robotics-opensource.bb
+++ b/recipes-products/packagegroups/packagegroup-robotics-opensource.bb
@@ -58,7 +58,6 @@ QRB_ROS_SAMPLE = " \
 # If you do not work within the above two organizations and are preparing to merge your code into the Qualcomm Linux Intelligence Robotics Image,
 # please place it in the following variable.
 EXTERNAL_OPENSOURCE = " \
-    ${ROS_GST_BRIDGE} \
     rplidar-ros2 \
     orbbec-camera \
     cartographer \

--- a/recipes-sdk/files/content_config.json
+++ b/recipes-sdk/files/content_config.json
@@ -13,10 +13,6 @@
             "to": "qirp-samples/platform/"
         },
         {
-            "name": "ros-gst-bridge",
-            "to": "qirp-samples/platform/"
-        },
-        {
             "name": "qrb-ros-benchmark",
             "to": "qirp-samples/platform/"
         },
@@ -76,7 +72,7 @@
       "scripts": [
         {
             "from_local":"qrb_ros_samples_scripts/qrb_ros_system_monitor/scripts",
-            "to": "qirp-samples/platform/qrb-ros-system-monitor/"
+            "to": "qirp-samples/platform/qrb_ros_system_monitor/"
         }
       ]
 }


### PR DESCRIPTION
CRs-Fixed: 4554889

Motivation:
- ROS package names typically use underscores (_) rather than hyphens (-).
- The sample copy logic used the original name with hyphens, causing path
  mismatches when ROS tools expected underscore-formatted package names
- ros-gst-bridge is a third-party open-source feature not validated by
  Qualcomm and should be removed from SDK samples

Impact:
- Sample directories now use underscore naming convention compatible with ROS
- ros-gst-bridge no longer included in SDK samples or package groups
- No breaking changes to existing samples that already use underscores