### PR TITLE
ci: drop kvm distro and exclude bug/perf builds from PR pipeline

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -3,6 +3,10 @@ name: Build Yocto
 on:
   workflow_call:
     inputs:
+      profile:
+        required: false
+        type: string
+        default: "full" # values: pr | full
       use_sstate:
         description: "Use SSTATE cache"
         required: false
@@ -145,6 +149,7 @@ jobs:
         uses: ./.github/actions/compile
         id: compile_kas
         with:
+          enabled: ${{inputs.profile != 'pr' || (matrix.distro.name != 'debug' && matrix.distro.name != 'performance')}}
           machine: ${{matrix.machine}}
           distro_yaml: ${{matrix.distro.yamlfile}}
           distro_name: ${{matrix.distro.name}}
@@ -159,7 +164,7 @@ jobs:
   publish_summary:
     needs: compile
     if: ${{ always() && github.repository_owner == 'qualcomm-linux' }}
-    runs-on: [self-hosted, qcom-u2404, amd64]
+    runs-on: ubuntu-latest
     steps:
       - name: 'Download build URLs'
         uses: actions/download-artifact@v7

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -37,3 +37,4 @@ jobs:
     uses: ./.github/workflows/build-yocto.yml
     with:
       use_sstate: ${{ inputs.use_sstate || 'true' }}
+      profile: pr

--- a/ci/qcom-distro-kvm.yml
+++ b/ci/qcom-distro-kvm.yml
@@ -4,5 +4,7 @@ header:
   version: 14
   includes:
    - ci/qcom-distro.yml
-
-distro: qcom-distro-kvm
+   
+local_conf_header:
+  kvm: |
+        MACHINE_FEATURES:append = " kvm"


### PR DESCRIPTION
CRs-Fixed: 4563391

Motivation:
- qcom-distro-kvm has been moved to MACHINE_FEATURES, making it
  redundant to keep it as a separate distro in the CI build matrix
- Remove the debug and performance build from PR build matrix to reduce build time

Impact:
- Reduces CI build matrix complexity and build time
- No functional change, as KVM support is now controlled via
  MACHINE_FEATURES
- Existing KVM functionality remains unchanged