### PR TITLE
feat: add qrb-ros-transport test packages

### DIFF
--- a/recipes-products/packagegroups/packagegroup-robotics-opensource.bb
+++ b/recipes-products/packagegroups/packagegroup-robotics-opensource.bb
@@ -20,9 +20,11 @@ QUALCOMM_QRB_ROS = " \
     ocr-service \
     lib-mem-dmabuf \
     dmabuf-transport \
+    dmabuf-transport-test \
     qrb-ros-transport-image-type \
     qrb-ros-transport-imu-type \
     qrb-ros-transport-point-cloud2-type \
+    qrb-ros-transport-test \
     qrb-sensor-client \
     qrb-ros-system-monitor \
     qrb-ros-system-monitor-interfaces \

--- a/recipes/dmabuf-transport/dmabuf-transport-test_1.0.0.bb
+++ b/recipes/dmabuf-transport/dmabuf-transport-test_1.0.0.bb
@@ -1,0 +1,67 @@
+inherit ros_distro_${ROS_DISTRO}
+inherit ros_component
+inherit ros_insane_dev_so
+
+ROS_BUILD_TYPE = "ament_cmake"
+
+inherit ros_${ROS_BUILD_TYPE}
+inherit robotics-package
+
+DESCRIPTION = "Test for ROS type adaption with Linux DMA buffer"
+AUTHOR = "Peng Wang <penwang@qti.qualcomm.com>"
+ROS_AUTHOR = "Peng Wang"
+SECTION = "devel"
+LICENSE = "BSD-3-Clause-Clear"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=86fcc2294062130b497ba0ffff9f82fc"
+
+ROS_CN = "dmabuf_transport_test"
+ROS_BPN = "dmabuf_transport_test"
+
+ROS_BUILD_DEPENDS = " \
+    rclcpp \
+    rclcpp-components \
+    sensor-msgs \
+    dmabuf-transport \
+    pcl \
+    pcl-conversions \
+"
+
+ROS_BUILDTOOL_DEPENDS = " \
+    ament-cmake-auto-native \
+"
+
+ROS_EXPORT_DEPENDS = " \
+    rclcpp \
+"
+
+ROS_BUILDTOOL_EXPORT_DEPENDS = ""
+
+ROS_EXEC_DEPENDS = " \
+    rclcpp \
+    rclcpp-components \
+    sensor-msgs \
+    pcl \
+    pcl-conversions \
+"
+
+ROS_TEST_DEPENDS = " \
+    ament-lint-auto \
+    ament-lint-common \
+    ament-cmake-lint-cmake \
+    ament-cmake-uncrustify \
+    ament-cmake-xmllint \
+    ament-cmake-cppcheck-native \
+    ament-cmake-flake8-native \
+    ament-cmake-pep257-native \
+    ament-uncrustify-native \
+    ament-lint-cmake-native \
+    ament-xmllint-native \
+"
+
+DEPENDS = "${ROS_BUILD_DEPENDS} ${ROS_BUILDTOOL_DEPENDS}"
+DEPENDS += "${ROS_EXPORT_DEPENDS} ${ROS_BUILDTOOL_EXPORT_DEPENDS} ${ROS_TEST_DEPENDS}"
+
+RDEPENDS:${PN} += "${ROS_EXEC_DEPENDS}"
+
+SRC_URI = "git://github.com/qualcomm-qrb-ros/dmabuf_transport.git;protocol=https;branch=dmabuf_transport_test"
+SRCREV = "b99aed729956575c6880057cea7ee99dbbf0f054"

--- a/recipes/qrb-ros-transport/qrb-ros-transport-test_1.3.0.bb
+++ b/recipes/qrb-ros-transport/qrb-ros-transport-test_1.3.0.bb
@@ -1,0 +1,73 @@
+inherit ros_distro_${ROS_DISTRO}
+inherit ros_component
+inherit ros_insane_dev_so
+
+ROS_BUILD_TYPE = "ament_cmake"
+
+inherit ros_${ROS_BUILD_TYPE}
+inherit robotics-package
+
+DESCRIPTION = "Test for QRB ROS transport"
+AUTHOR = "Peng Wang <penwang@qti.qualcomm.com>"
+ROS_AUTHOR = "Peng Wang"
+SECTION = "devel"
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://../LICENSE;md5=86fcc2294062130b497ba0ffff9f82fc"
+
+ROS_CN = "qrb_ros_transport_test"
+ROS_BPN = "qrb_ros_transport_test"
+
+ROS_BUILD_DEPENDS = " \
+    rclcpp \
+    rclcpp-components \
+    sensor-msgs \
+    qrb-ros-transport-image-type \
+    qrb-ros-transport-imu-type \
+    qrb-ros-transport-point-cloud2-type \
+    pcl \
+    pcl-conversions \
+"
+
+ROS_BUILDTOOL_DEPENDS = " \
+    ament-cmake-auto-native \
+"
+
+ROS_EXPORT_DEPENDS = " \
+    rclcpp \
+"
+
+ROS_BUILDTOOL_EXPORT_DEPENDS = ""
+
+ROS_EXEC_DEPENDS = " \
+    rclcpp \
+    rclcpp-components \
+    sensor-msgs \
+    qrb-ros-transport-image-type \
+    qrb-ros-transport-imu-type \
+    qrb-ros-transport-point-cloud2-type \
+    pcl \
+    pcl-conversions \
+"
+
+ROS_TEST_DEPENDS = " \
+    ament-lint-auto \
+    ament-lint-common \
+    ament-cmake-lint-cmake \
+    ament-cmake-uncrustify \
+    ament-cmake-xmllint \
+    ament-cmake-cppcheck-native \
+    ament-cmake-flake8-native \
+    ament-cmake-pep257-native \
+    ament-uncrustify-native \
+    ament-lint-cmake-native \
+    ament-xmllint-native \
+"
+
+DEPENDS = "${ROS_BUILD_DEPENDS} ${ROS_BUILDTOOL_DEPENDS}"
+DEPENDS += "${ROS_EXPORT_DEPENDS} ${ROS_BUILDTOOL_EXPORT_DEPENDS} ${ROS_TEST_DEPENDS}"
+
+RDEPENDS:${PN} += "${ROS_EXEC_DEPENDS}"
+
+SRC_URI = "git://github.com/qualcomm-qrb-ros/qrb_ros_transport.git;protocol=https;branch=stable/1.3.0"
+SRCREV = "72642db004e4cf58208c72733dd8da6d74339d58"
+S = "${UNPACKDIR}/${PN}-${PV}/qrb_ros_transport_test"


### PR DESCRIPTION
CRs-Fixed: 4570475

Motivation:
Add qrb-ros-transport-test and dmabuf-transport-test packages on mainline platform

Impact:
The qrb-ros-transport-test and dmabuf-transport-test packages will be installed to /opt/ros/jazzy and packaged to qirp sdk. Not need extra installation steps for test functions.