### PR TITLE
fix: correct license and source path for test packages

### DIFF
--- a/recipes/dmabuf-transport/dmabuf-transport-test_1.0.0.bb
+++ b/recipes/dmabuf-transport/dmabuf-transport-test_1.0.0.bb
@@ -65,3 +65,5 @@ RDEPENDS:${PN} += "${ROS_EXEC_DEPENDS}"
 
 SRC_URI = "git://github.com/qualcomm-qrb-ros/dmabuf_transport.git;protocol=https;branch=dmabuf_transport_test"
 SRCREV = "b99aed729956575c6880057cea7ee99dbbf0f054"
+S = "${UNPACKDIR}/${PN}-${PV}"
+

--- a/recipes/qrb-ros-transport/qrb-ros-transport-test_1.3.0.bb
+++ b/recipes/qrb-ros-transport/qrb-ros-transport-test_1.3.0.bb
@@ -11,7 +11,7 @@ DESCRIPTION = "Test for QRB ROS transport"
 AUTHOR = "Peng Wang <penwang@qti.qualcomm.com>"
 ROS_AUTHOR = "Peng Wang"
 SECTION = "devel"
-LICENSE = "BSD-3-Clause"
+LICENSE = "BSD-3-Clause-Clear"
 LIC_FILES_CHKSUM = "file://../LICENSE;md5=86fcc2294062130b497ba0ffff9f82fc"
 
 ROS_CN = "qrb_ros_transport_test"


### PR DESCRIPTION
CRs-Fixed: 4574476

Motivation:
- Fix package license and source path in recipes.

Impact:
- Fix build and lint warning for package informations.