### PR TITLE
fix(main): correct robotic distro and patch signed-off

### DIFF
--- a/ci/qcom-robotics-distro-catchall.yml
+++ b/ci/qcom-robotics-distro-catchall.yml
@@ -5,5 +5,5 @@ header:
   includes:
    - ci/qcom-robotics-distro.yml
 
-distro: qcom-distro-catchall
+distro: qcom-robotics-distro-catchall
 

--- a/conf/distro/qcom-robotics-distro-catchall.conf
+++ b/conf/distro/qcom-robotics-distro-catchall.conf
@@ -1,10 +1,9 @@
 # Copyright (c) 2025 Qualcomm Innovation Center, Inc. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-require conf/distro/include/qcom-base.inc
+require conf/distro/qcom-distro-catchall.conf
 require conf/distro/include/qcom-robotics-sdk.inc
 
-require conf/distro/qcom-distro-selinux.conf
-require conf/distro/qcom-distro-sota.conf
-require conf/distro/qcom-distro-ros2-jazzy.conf
+DISTRO_FEATURES:append = " ros2-jazzy"
 
+DISTRO_NAME = "Qualcomm Linux Robotics Reference Distro with ROS(SOTA and SELinux enabled)"

--- a/conf/distro/qcom-robotics-distro-selinux.conf
+++ b/conf/distro/qcom-robotics-distro-selinux.conf
@@ -1,9 +1,5 @@
 # Copyright (c) 2025 Qualcomm Innovation Center, Inc. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-require conf/distro/include/qcom-robotics-sdk.inc
+require conf/distro/qcom-robotics-ros2-jazzy.conf
 require conf/distro/qcom-distro-selinux.conf
-
-DISTRO_NAME = "QCOM Robotics Reference Distro with ROS"
-
-DISTRO_FEATURES:append = " ros2-jazzy"

--- a/conf/distro/qcom-robotics-distro-sota.conf
+++ b/conf/distro/qcom-robotics-distro-sota.conf
@@ -1,9 +1,5 @@
 # Copyright (c) 2025 Qualcomm Innovation Center, Inc. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-require conf/distro/include/qcom-robotics-sdk.inc
+require conf/distro/qcom-robotics-ros2-jazzy.conf
 require conf/distro/qcom-distro-sota.conf
-
-DISTRO_NAME = "QCOM Robotics Reference Distro with ROS"
-
-DISTRO_FEATURES:append = " ros2-jazzy"

--- a/conf/distro/qcom-robotics-ros2-jazzy.conf
+++ b/conf/distro/qcom-robotics-ros2-jazzy.conf
@@ -4,6 +4,6 @@
 require conf/distro/include/qcom-robotics-sdk.inc
 require conf/distro/qcom-distro.conf
 
-DISTRO_NAME = "QCOM Robotics Reference Distro with ROS"
+DISTRO_NAME = "Qualcomm Linux Robotics Reference Distro with ROS"
 
 DISTRO_FEATURES:append = " ros2-jazzy"

--- a/recipes/cartographer-ros/files/0002-Fix-miniglog-real-glog-header-conflict.patch
+++ b/recipes/cartographer-ros/files/0002-Fix-miniglog-real-glog-header-conflict.patch
@@ -2,7 +2,7 @@
 # Copyright (c) 2026 Qualcomm Innovation Center, Inc. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 From 0000000000000000000000000000000000000002 Mon Sep 17 00:00:00 2001
-From: Claude Code <noreply@anthropic.com>
+From: Teng Fan <tengf@qti.qualcomm.com>
 Date: Wed Jun 10 2026 18:00:00 +0000
 Subject: [PATCH] Fix miniglog/real-glog header conflict in cartographer-ros
 
@@ -20,7 +20,7 @@ The cartographer library was compiled with miniglog and does not need
 it re-exported to consumers that also link real glog.
 
 Upstream-Status: Inappropriate [platform specific - ceres miniglog conflict]
-Signed-off-by: Claude Code <noreply@anthropic.com>
+Signed-off-by: Teng Fan <tengf@qti.qualcomm.com>
 ---
  cartographer_ros/CMakeLists.txt | 12 ++++++++++++
  1 file changed, 12 insertions(+)

--- a/recipes/cartographer/files/0003-Fix-Werror-return-type-with-miniglog-LOG-FATAL.patch
+++ b/recipes/cartographer/files/0003-Fix-Werror-return-type-with-miniglog-LOG-FATAL.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Fix <fix@fix.fix>
+From: Teng Fan <tengf@qti.qualcomm.com>
 Date: Tue, 10 Jun 2026 00:00:00 +0000
 Subject: [PATCH] Fix build errors caused by ceres miniglog
 
@@ -20,7 +20,7 @@ Changes:
    CHECK_LE on absolute difference.
 
 Upstream-Status: Inappropriate [platform specific]
-Signed-off-by: Fix <fix@fix.fix>
+Signed-off-by: Teng Fan <tengf@qti.qualcomm.com>
 ---
  cartographer/mapping/internal/imu_based_pose_extrapolator.cc | 2 +-
  cartographer/mapping/internal/motion_filter.cc               | 2 +-


### PR DESCRIPTION
CRs-Fixed: 4575102

Motivation:
- Correct the robotics catchall distro config.
- Update cartographer signed-off information.

Impact:
- Update qcom-robotics-catchall distro with correct configuration.