### PR TITLE
feat(wrynose): update SDK_VERSION to 2.7.0

### DIFF
--- a/classes/psdk-image.bbclass
+++ b/classes/psdk-image.bbclass
@@ -20,7 +20,7 @@
 #
 TOOLCHAIN_PATH = "${DEPLOY_DIR}/sdk"
 SDK_PN = "qirp-sdk"
-SDK_VERSION = "2.4.0"
+SDK_VERSION = "2.7.0"
 OSS_CHANNEL_FLAG = "${@bb.utils.contains_any('BBFILE_COLLECTIONS', 'qcom-robotics-extras', 'false', 'true', d)}"
 
 # Collect the standard SDK toolchain and copy it into the SDK's toolchain/

--- a/recipes-sdk/qirp-sdk.bb
+++ b/recipes-sdk/qirp-sdk.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = " \
     file://LICENSE.txt;md5=2998c54c288b081076c9af987bdf4838 \
 "
 
-PV = "2.4.0"
+PV ?= "${SDK_VERSION}"
 S = "${UNPACKDIR}"
 # Run-time dependent scripts are used to configure the system runtime environment.
 FILES:${PN} = "/usr/share/qirp-setup.sh"


### PR DESCRIPTION
CRs-Fixed: 4583040

Motivation:
- Bump SDK version from 2.4.0 to 2.7.0 to align with the latest release.
- Avoid hardcoding PV in qirp-sdk.bb by deriving it from SDK_VERSION for better maintainability and consistency across recipes.

Impact:
- Ensures SDK version is centrally managed via SDK_VERSION.
- Reduces duplication and risk of version mismatch between class and recipe.
- Automatically updates package version when SDK_VERSION changes.