### PR TITLE
ci(chore): update monthly task runner label

### DIFF
--- a/.github/workflows/monthly.yml
+++ b/.github/workflows/monthly.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   sstate-cache-cleanup:
     if: github.repository_owner == 'qualcomm-linux'
-    runs-on: [self-hosted, gen-qlnx-prd-u2404-x64-sm-od-ephem]    
+    runs-on: [self-hosted, qcom-u2404, amd64] 
     timeout-minutes: 720
     steps:
       - name: Clean up the persistant sstate-cache dir

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -37,21 +37,3 @@ jobs:
     uses: ./.github/workflows/build-yocto.yml
     with:
       use_sstate: ${{ inputs.use_sstate || 'true' }}
-
-  auto-merge:
-    name: "Auto merge PR if automation label"
-    runs-on: ubuntu-latest
-    needs: build-pr
-    # Only run on pull_request events (not workflow_dispatch), and only if the label is "automation"
-    if: |
-      github.event_name == 'pull_request' &&
-      contains(github.event.pull_request.labels.*.name, 'automation')
-    steps:
-      - name: Merge PR
-        env:
-          GH_TOKEN: ${{ secrets.SDK_LAYER_TOKEN }}
-        run: |
-          gh pr merge ${{ github.event.pull_request.number }} \
-            --repo ${{ github.repository }} \
-            --merge \
-            --auto


### PR DESCRIPTION
CRs-Fixed: 4583040

Motivation:
- Update the runner label for monthly workflow execution.
- Remove the auto-merge job, as GitHub branch protection rules now prohibit auto-merge.

Impact:
- The runner will clean up outdated build cache folders on a monthly basis.
- Pull requests with the "automation" label must now be merged manually.
