### PR TITLE
ci(automation): update the commit id from meta-qcom (wrynose): 28125438792

### DIFF
--- a/ci/base.lock.yml
+++ b/ci/base.lock.yml
@@ -10,6 +10,8 @@ overrides:
             commit: 22021758e66737bcf68dfd2b74adc6a0cb1d42d9
         meta-arm:
             commit: d3b55902fb9963978be90d6f283296de456b4b63
+        meta-qcom-distro:
+            commit: 775dc8c710f382ef8183000e7f0d40bc7dcf61cc
         meta-openembedded:
             commit: 9af4488d46cb4fd4c0d2d64820c86225ebd6ac71
         meta-virtualization:


### PR DESCRIPTION
CRs-Fixed: 4586669 
## Auto-update from meta-qcom Nightly Build (wrynose)

This pull request automatically updates the repository commits from the latest meta-qcom wrynose nightly build.

**Build Details:**
- meta-qcom nightly build url: https://github.com/qualcomm-linux/meta-qcom/actions/runs/28125438792
- Check and download actions url: https://github.com/DotaIsMind/meta-qcom-robotics-sdk/actions/runs/28212576825
- Timestamp: Fri Jun 26 02:07:44 UTC 2026