### PR TITLE
fix: add PREMIRRORS for docker fetch task

### DIFF
--- a/ci/base.lock.yml
+++ b/ci/base.lock.yml
@@ -10,6 +10,8 @@ overrides:
             commit: 22021758e66737bcf68dfd2b74adc6a0cb1d42d9
         meta-arm:
             commit: d3b55902fb9963978be90d6f283296de456b4b63
+        meta-qcom-distro:
+            commit: 775dc8c710f382ef8183000e7f0d40bc7dcf61cc
         meta-openembedded:
             commit: 9af4488d46cb4fd4c0d2d64820c86225ebd6ac71
         meta-virtualization:

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -24,3 +24,8 @@ ROS_UNRESOLVED_DEP-libnanoflann-dev:forcevariable = "nanoflann"
 
 ROBIOTICS_LAYER_DIR = "${LAYERDIR}"
 COMMON_LICENSE_DIR = "${COREBASE}/meta/files/common-licenses"
+
+# Add PREMIRROR for docker-compose fetch
+PREMIRRORS:prepend = " \
+    https://proxy.golang.org/.*   ${QLI_MIRRORS_URI}/ \
+"

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -25,7 +25,7 @@ ROS_UNRESOLVED_DEP-libnanoflann-dev:forcevariable = "nanoflann"
 ROBIOTICS_LAYER_DIR = "${LAYERDIR}"
 COMMON_LICENSE_DIR = "${COREBASE}/meta/files/common-licenses"
 
-# Add PREMIRROR for docker-compose fetch
-PREMIRRORS:prepend = " \
-    https://proxy.golang.org/.*   ${QLI_MIRRORS_URI}/ \
+# All the download files of meta-qcom layer have been deployed on this server.
+PREMIRRORS:prepend = "\
+.*://.*/.* https://artifacts.codelinaro.org/qli-ci/downloads/2.x/ \n \
 "


### PR DESCRIPTION
CRs-Fixed: 4586669

Motivation:
- Add PREMIRRORS for deocker-compose fetch failure cause QLI_MIRRORS has no gomod protocol.

Impact:
- docker-compose and nerdctl fetch tasks will download normally and speed up to less than one hours.