### PR TITLE
ci/qcom-distro: update the URL for meta-virtualization

### DIFF
--- a/ci/qcom-distro.yml
+++ b/ci/qcom-distro.yml
@@ -29,7 +29,7 @@ repos:
       meta-xfce:
 
   meta-virtualization:
-    url: https://git.yoctoproject.org/git/meta-virtualization
+    url: https://git.yoctoproject.org/meta-virtualization
 
   meta-audioreach:
     url: https://github.com/AudioReach/meta-audioreach


### PR DESCRIPTION
**Motivation**
port #2630 to meta-qcom-robotics-sdk to solve meta-virtualization always fetch failure issue

**Impact**
use URL https://git.yoctoproject.org/meta-virtualization