### PR TITLE
chore(ci): update meta-ros to dbb05e0b (wrynose)

### DIFF
--- a/ci/qcom-robotics-distro.yml
+++ b/ci/qcom-robotics-distro.yml
@@ -42,7 +42,7 @@ repos:
       remove-rosbag2-compressionn-zstd-bbappend:
         repo: meta-qcom-robotics-sdk
         path: patches/0001-fix-remove-bbappend-and-patch-for-rosbag2-compressio.patch
-    commit: 7e5153fb3dae940cfaa2d823df651bbb1f768c79
+    commit: dbb05e0b4430cd26dc2a9973cc4d70bb46d6b354
 local_conf_header:
   resource_limitation: '# Capture the count of cpu cores available from the host.
 


### PR DESCRIPTION
## Summary

Update `meta-ros` commit hash to the latest upstream `wrynose` branch.

| | Commit |
|---|---|
| **Previous** | `7e5153fb3dae940cfaa2d823df651bbb1f768c79` |
| **New** | `dbb05e0b4430cd26dc2a9973cc4d70bb46d6b354` |

## Motivation

meta-ros upstream has new commits on the `wrynose` branch. This update
pulls in the latest upstream changes.

## Impact

Pulls in upstream meta-ros changes. Patch compatibility has not been
verified automatically; manual review is required.

## TODO

- [ ] Verify that the following patches still apply cleanly:
  - `patches/0001-fix-Update-LAYERSERIES_COMPAT-to-adapt-to-upstream-u.patch`
  - `patches/0001-fix-remove-bbappend-and-patch-for-rosbag2-compressio.patch`
  - `patches/0001-jazzy-remove-outdated-bbappend-and-patches-of-stomp.patch`
  - `patches/0001-ros2-ament_cmake-add-python-configurations-for-class.patch`
  - `patches/0002-jazzy-update-libdir-of-ompl.patch`
  - `patches/0003-jazzy-move-some-nav2-and-moveit-packages-out-of-blac.patch`
  - `patches/Initial-commit-of-license.patch`
