### PR TITLE
ci(automation): update the commit id from meta-qcom (wrynose): 28688115050

### DIFF
--- a/ci/base.lock.yml
+++ b/ci/base.lock.yml
@@ -5,17 +5,15 @@ overrides:
         oe-core:
             commit: 06dd66e6220e5ce4ed4b9af4d8231ae5f0a8ce80
         meta-lts-mixins:
-            commit: 348a9eaaf3991e2329d0cef14dce23fabaef9191
+            commit: 6ad95d00531b32ec01792ab496718943dc95277b
         bitbake:
             commit: 22021758e66737bcf68dfd2b74adc6a0cb1d42d9
         meta-arm:
             commit: d3b55902fb9963978be90d6f283296de456b4b63
-        meta-qcom-distro:
-            commit: 775dc8c710f382ef8183000e7f0d40bc7dcf61cc
         meta-openembedded:
-            commit: 9af4488d46cb4fd4c0d2d64820c86225ebd6ac71
+            commit: a43f0d532c399458cae44ce66f3799a220fbb497
         meta-virtualization:
-            commit: 959a211fbba059689a1c3a1b24fe0abb9224281a
+            commit: 781735b97ae5013cacabbecd38e6da6b510cf3fb
         meta-audioreach:
             commit: c80ebf5be5cc47a1bab1acb4b1987c8cd8b48218
         meta-selinux:

--- a/ci/qcom-robotics-distro.yml
+++ b/ci/qcom-robotics-distro.yml
@@ -10,7 +10,7 @@ repos:
     branch: wrynose
   meta-qcom:
     url: https://github.com/qualcomm-linux/meta-qcom
-    commit: ef0004df267743cc89d6a09bc724bc99ff541c01 
+    commit: ef0004df267743cc89d6a09bc724bc99ff541c01
   oe-core:
     url: https://github.com/openembedded/openembedded-core
     layers:

--- a/conf/distro/include/qcom-robotics-sdk.inc
+++ b/conf/distro/include/qcom-robotics-sdk.inc
@@ -51,3 +51,6 @@ TOOLCHAIN_HOST_TASK:append = "${@(' ' + (d.getVar('ROS_SDK_HOST_PACKAGES') or ''
 #    are not covered and fail with "setscene ignore_tasks".
 #    Fix: add *:do_collect_rdepends to allow it to run from scratch.
 BB_SETSCENE_ENFORCE_IGNORE_TASKS:append = " *:do_collect_rdepends"
+
+PREFERRED_VERSION_linux-firmware = "20260622"
+


### PR DESCRIPTION
## Auto-update from meta-qcom Nightly Build (wrynose)

This pull request automatically updates the repository commits from the latest meta-qcom wrynose nightly build.

**Build Details:**
- meta-qcom nightly build url: https://github.com/qualcomm-linux/meta-qcom/actions/runs/28688115050
- Check and download actions url: https://github.com/TengFan-QC/meta-qcom-robotics-sdk/actions/runs/28782430887
- Timestamp: Mon Jul  6 09:42:29 UTC 2026