### PR TITLE
ci(automation): update the commit id from meta-qcom (wrynose): 28983460036

### DIFF
--- a/.github/actions/compile/action.yml
+++ b/.github/actions/compile/action.yml
@@ -80,7 +80,7 @@ runs:
       shell: bash
       run: |
         $KAS_CONTAINER shell ci/mirror.yml:ci/${{ inputs.machine }}.yml${{ inputs.distro_yaml }}${{ inputs.target_yaml }}${{ inputs.kernel_yaml }} --command "\
-        sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends gfortran && \
+        sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends gfortran groff && \
         bitbake ${{ inputs.target_name }} && bitbake ${{ inputs.target_name }} -c generate_qirp_sdk"
         
         ci/kas-container-shell-helper.sh ci/yocto-pybootchartgui.sh

--- a/ci/base.lock.yml
+++ b/ci/base.lock.yml
@@ -3,21 +3,19 @@ header:
 overrides:
     repos:
         oe-core:
-            commit: 06dd66e6220e5ce4ed4b9af4d8231ae5f0a8ce80
+            commit: 5d1aa5c806c061a2994f4decb59016610f093213
         meta-lts-mixins:
-            commit: 348a9eaaf3991e2329d0cef14dce23fabaef9191
+            commit: 6ad95d00531b32ec01792ab496718943dc95277b
         bitbake:
-            commit: 22021758e66737bcf68dfd2b74adc6a0cb1d42d9
+            commit: acfe02fa38b5da9e6a36c6cedcf91d4fcbefbfbd
         meta-arm:
-            commit: d3b55902fb9963978be90d6f283296de456b4b63
-        meta-qcom-distro:
-            commit: 775dc8c710f382ef8183000e7f0d40bc7dcf61cc
+            commit: caa36c53f796beb25d9b9f58b1b7a492e9987e15
         meta-openembedded:
-            commit: 9af4488d46cb4fd4c0d2d64820c86225ebd6ac71
+            commit: 100027977216601000cbefc42c2ff6cf667e7b5e
         meta-virtualization:
-            commit: 959a211fbba059689a1c3a1b24fe0abb9224281a
+            commit: 781735b97ae5013cacabbecd38e6da6b510cf3fb
         meta-audioreach:
-            commit: c80ebf5be5cc47a1bab1acb4b1987c8cd8b48218
+            commit: bb3f812fa666fa1a03279b77e2c75f529ee9d797
         meta-selinux:
             commit: 1c3a699f363167571ab39fecb0fe6f56691a4e20
         meta-updater:
@@ -25,4 +23,4 @@ overrides:
         meta-security:
             commit: c0d1d6200e7a84c39fb940cb1f22aad4b0b3d808
         meta-dpdk:
-            commit: c4e58978ce61c47c2f54206e07f9ad46be2ed257
+            commit: ded70edc0937d939596a0c38b737af59afbb5e7b

--- a/ci/qcom-distro.yml
+++ b/ci/qcom-distro.yml
@@ -15,10 +15,6 @@ repos:
 
   meta-openembedded:
     url: https://github.com/openembedded/meta-openembedded
-    patches:
-      plain:
-        repo: meta-qcom
-        path: patches/meta-oe/0001-mariadb-fix-building-for-the-ARMv8.3-A-and-later-sys.patch
     layers:
       meta-filesystems:
       meta-gnome:

--- a/ci/qcom-robotics-distro.yml
+++ b/ci/qcom-robotics-distro.yml
@@ -10,7 +10,6 @@ repos:
     branch: wrynose
   meta-qcom:
     url: https://github.com/qualcomm-linux/meta-qcom
-    commit: ef0004df267743cc89d6a09bc724bc99ff541c01 
   oe-core:
     url: https://github.com/openembedded/openembedded-core
     layers:


### PR DESCRIPTION
CRs-Fixed: 4598714

Auto-update from meta-qcom Nightly Build (wrynose)

This pull request updates repository revisions to align with the latest meta-qcom wrynose nightly build.

Build Details:
- meta-qcom nightly build: https://github.com/qualcomm-linux/meta-qcom/actions/runs/28983460036
- Validation and download workflow: https://github.com/TengFan-QC/meta-qcom-robotics-sdk/actions/runs/29004490113
- Timestamp: Thu Jul 9 08:22:22 UTC 2026

Additional Changes:
- Remove the code freeze restrictions for the meta-qcom and meta-qcom-distro layers.
- Add the host-side groff dependency required for documentation generation by buildtools-tarball components such as perl and sed. This addresses CI build failures caused by missing groff installations on clean build hosts.