### PR TITLE
ci: fix LAVA overlay path and results directory

### DIFF
--- a/ci/lava/qcom-robotics-distro/iq-9075-evk/boot.yaml
+++ b/ci/lava/qcom-robotics-distro/iq-9075-evk/boot.yaml
@@ -12,7 +12,7 @@ actions:
         - export IMAGE_PATH=$PWD
         - cp overlay*.tar.gz overlay.tar.gz
         - echo "OVERLAY=overlay.tar.gz" >> $IMAGE_PATH/flash.settings
-        - echo "OVERLAY_PATH=/home/" >> $IMAGE_PATH/flash.settings
+        - echo "OVERLAY_PATH=/" >> $IMAGE_PATH/flash.settings
         - echo "DEVICE_TYPE=qcs9100-rb8" >> $IMAGE_PATH/flash.settings
         - cat $IMAGE_PATH/flash.settings
     timeout:
@@ -52,7 +52,6 @@ actions:
 - command:
     name: network_turn_on
 context:
-  lava_test_results_dir: /home/lava-%s
   test_character_delay: 10
 device_type: {{DEVICE_TYPE}}
 job_name: boot test ({{DEVICE_TYPE}}) {{GITHUB_RUN_ID}}


### PR DESCRIPTION
CRs-Fixed: 4598715

Root cause:
Current LAVA boot.yml config setting rootfs is writable and path is `"/"`, this is outdated and blocking the CI LAVA test job. 

Motivation:
The overlay should be extracted from the root directory instead of /home, and
the custom LAVA test results directory is no longer required.

Impact:
Fixes the overlay deployment path and relies on the default LAVA test results
directory handling for IQ-9075-EVK boot tests.
