### PR TITLE
[Backport wrynose] ci: fix LAVA overlay path and results directory

### DIFF
--- a/ci/lava/qcom-robotics-distro/iq-9075-evk/boot+linux-qcom-6.18.yaml
+++ b/ci/lava/qcom-robotics-distro/iq-9075-evk/boot+linux-qcom-6.18.yaml
@@ -12,7 +12,7 @@ actions:
         - export IMAGE_PATH=$PWD
         - cp overlay*.tar.gz overlay.tar.gz
         - echo "OVERLAY=overlay.tar.gz" >> $IMAGE_PATH/flash.settings
-        - echo "OVERLAY_PATH=/home/" >> $IMAGE_PATH/flash.settings
+        - echo "OVERLAY_PATH=/" >> $IMAGE_PATH/flash.settings
         - echo "DEVICE_TYPE=qcs9100-rb8" >> $IMAGE_PATH/flash.settings
         - cat $IMAGE_PATH/flash.settings
     timeout:
@@ -52,7 +52,6 @@ actions:
 - command:
     name: network_turn_on
 context:
-  lava_test_results_dir: /home/lava-%s
   test_character_delay: 10
 device_type: {{DEVICE_TYPE}}
 job_name: boot test ({{DEVICE_TYPE}}) {{GITHUB_RUN_ID}}


### PR DESCRIPTION
# Description
Backport of #318 to `wrynose`.