### PR TITLE
ci(automation): update the commit id from meta-qcom (master): 30137414967

### DIFF
--- a/ci/base.lock.yml
+++ b/ci/base.lock.yml
@@ -3,24 +3,24 @@ header:
 overrides:
     repos:
         oe-core:
-            commit: f810998ac90f7a3e20e26555f39d754b16ce8b69
+            commit: 62d2381bdee1cebb5924f8594f8a9994083d4f7d
         bitbake:
-            commit: 7e3489ab3ec39b2dcf4e50eff54d36d42e5a7307
+            commit: 3a99c26fa581d70ed67bd08a5e0e0d0b18369a7c
         meta-arm:
-            commit: 847af9c082cc190b3781f101200a9403426e481b
+            commit: 28606c721503b70e8343968731a24260cfe985bc
         meta-openembedded:
-            commit: a7428c96bf97a751ccd5baa63acfa1f5b49f077e
+            commit: dc0ccaa27311b3379749ecf44f98c0b5e249902e
         meta-virtualization:
             commit: 022f4356d4a9b389f51472d40a9330aa59f6bb9a
         meta-audioreach:
-            commit: c80ebf5be5cc47a1bab1acb4b1987c8cd8b48218
+            commit: b5a382aba0e5b1e4cfbd9f36256ea46e0d4cf002
         meta-selinux:
             commit: 7351443c6579671bcf048817438f1740ad23eaab
         meta-updater:
-            commit: f0e1ccafaa877d2781ed953236981dac57439dc8
+            commit: fff4a58a057c26ec0a2067ea5f32acd75ef7add4
         meta-security:
             commit: 226839ac408223f8041cde1b1d8b762d6fbc8050
         meta-dpdk:
             commit: ded70edc0937d939596a0c38b737af59afbb5e7b
         meta-ai:
-            commit: 6e46e36155ff181fb45d9cb5d290d9a3480bf6f7
+            commit: c6bd686178d1dcf3b9b4c859058428ede406f7d1

--- a/ci/qcom-robotics-distro.yml
+++ b/ci/qcom-robotics-distro.yml
@@ -2,12 +2,19 @@ header:
   version: 14
   includes:
   - ci/qcom-distro.yml
+defaults:
+  repos:
+    branch: master
 repos:
   meta-qcom-robotics-sdk:
     branch: main
   meta-qcom:
     url: https://github.com/qualcomm-linux/meta-qcom
-    commit: d2dda53767a99880287691c2d8ea1e1dd6f81ae2
+    commit: a1978c6c3e4f6e5fd0cd90dfbea3f130210818f8
+  meta-qcom-distro:
+    url: https://github.com/qualcomm-linux/meta-qcom-distro
+    branch: main
+    commit: 5a9bc8bf794cd857ad1986d4c73341ad98b42c48
   oe-core:
     url: https://github.com/openembedded/openembedded-core
     layers:
@@ -17,49 +24,6 @@ repos:
         repo: meta-qcom-robotics-sdk
         path: patches/Initial-commit-of-license.patch
     commit: 31edc0b82a3dc7b1dd0338da4a8d0d8f5a1dc138
-  bitbake:
-    url: https://github.com/openembedded/bitbake
-    layers:
-      .: disabled
-    commit: 797b0a348d7426d03459e577feacd3488fdeee47
-  meta-qcom-distro:
-    url: https://github.com/qualcomm-linux/meta-qcom-distro
-    branch: main
-    commit: e3a82c893760632b89ad0918265ab2bf82f2ed8a
-  meta-openembedded:
-    url: https://github.com/openembedded/meta-openembedded
-    layers:
-      meta-filesystems:
-      meta-gnome:
-      meta-multimedia:
-      meta-networking:
-      meta-oe:
-      meta-python:
-      meta-xfce:
-    commit: 39321ae90b64e8f2bd890a2957a5f80e74d4de30
-  meta-virtualization:
-    url: https://git.yoctoproject.org/meta-virtualization
-    branch: master
-    commit: 022f4356d4a9b389f51472d40a9330aa59f6bb9a
-  meta-audioreach:
-    url: https://github.com/AudioReach/meta-audioreach
-    branch: master
-    commit: c80ebf5be5cc47a1bab1acb4b1987c8cd8b48218
-  meta-selinux:
-    branch: master
-    url: https://git.yoctoproject.org/meta-selinux
-    commit: 1c30b4eddcef9e0594dd15c15e1f675e2a0c93a2
-  meta-updater:
-    branch: master
-    url: https://github.com/uptane/meta-updater
-    commit: f0e1ccafaa877d2781ed953236981dac57439dc8
-  meta-security:
-    url: https://git.yoctoproject.org/meta-security
-    branch: master
-    layers:
-      .:
-      meta-tpm:
-    commit: 226839ac408223f8041cde1b1d8b762d6fbc8050
   meta-ros:
     url: https://github.com/ros/meta-ros.git
     branch: master
@@ -130,13 +94,6 @@ local_conf_header:
     PARALLEL_MAKE ?= "-j ${THREAD_COUNT} -l ${THREAD_COUNT}"
 
     '
-  libcamera_mask: '# Disable the libcamera recipe to avoid conflicts with the meta-qcom-distro
-    libcamera recipe
 
-    BBMASK .= "|^${TOPDIR}/meta-ros/meta-ros-common/recipes-multimedia/libcamera/.*"
-
-    PREFERRED_VERSION_libcamera = "1:0.6.0"
-
-    '
 distro: qcom-robotics-ros2-jazzy
 target: qcom-robotics-image

--- a/recipes-bbappends/recipe-ros/navigation2/hardware-interface_%.bbappend
+++ b/recipes-bbappends/recipe-ros/navigation2/hardware-interface_%.bbappend
@@ -1,8 +1,6 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 SRC_URI:remove = "file://use-tinyxml-by-name.patch"
 
-EXTRA_OECMAKE += "-Wno-error"
-
 CXXFLAGS:append = " -I${STAGING_INCDIR}/pal_statistics -I${STAGING_INCDIR}/pal_statistics/pal_statistics"
 
 


### PR DESCRIPTION
CRs-Fixed: 4626464

Motivation:
Remove pinned meta-qcom commit and drop redundant layer repositories from qcom-robotics-distro.yml.

Impact:
The manifest now relies on dependencies provided through meta-qcom instead of explicitly listing upstream Yocto layers and related repositories, reducing maintenance overhead and keeping repository definitions centralized.

Based on meta-com nightly build: 
**Auto-update from meta-qcom Nightly Build (master)**

This pull request automatically updates the repository commits from the latest meta-qcom master nightly build.

**Build Details:**
- meta-qcom nightly build url: https://github.com/qualcomm-linux/meta-qcom/actions/runs/30137414967
- Check and download actions url: https://github.com/TengFan-QC/meta-qcom-robotics-sdk/actions/runs/30230897502
- Timestamp: Mon Jul 27 01:55:14 UTC 2026