### PR TITLE
[Backport wrynose] fix(xsens-mti-ros2-driver): raise XDA buffer size and align recipe conventions

### DIFF
--- a/recipes/xsens-mti-ros2-driver/files/0001-Increase-XdaCallback-max-buffer-size-to-32.patch
+++ b/recipes/xsens-mti-ros2-driver/files/0001-Increase-XdaCallback-max-buffer-size-to-32.patch
@@ -1,0 +1,34 @@
+# This patch file is from Qualcomm Innovation Center, Inc. and is provided under the following license:
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+From: Weijie Shen <weijshen@qti.qualcomm.com>
+Date: Thu, 23 Jul 2026 00:00:00 +0800
+Subject: [PATCH] Increase XdaCallback default max buffer size to 32
+
+Raise the XdaCallback default maxBufferSize from 5 to 32 so that more
+inbound XDA data packets can be queued before the consumer drains them.
+This reduces the chance of dropped IMU packets at higher output data
+rates.
+
+Upstream-Status: Pending
+Signed-off-by: Weijie Shen <weijshen@qti.qualcomm.com>
+---
+ include/xdacallback.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/xdacallback.h b/include/xdacallback.h
+index d5eeb17..3ecfb28 100644
+--- a/include/xdacallback.h
++++ b/include/xdacallback.h
+@@ -49,7 +49,7 @@ struct XsDevice;
+ class XdaCallback : public XsCallback
+ {
+ public:
+-	XdaCallback(rclcpp::Node::SharedPtr node, size_t maxBufferSize = 5);
++	XdaCallback(rclcpp::Node::SharedPtr node, size_t maxBufferSize = 32);
+ 	virtual ~XdaCallback() throw();
+ 
+ 	RosXsDataPacket next(const std::chrono::milliseconds &timeout);
+-- 
+2.34.1

--- a/recipes/xsens-mti-ros2-driver/xsens-mti-ros2-driver_1.0.2.bb
+++ b/recipes/xsens-mti-ros2-driver/xsens-mti-ros2-driver_1.0.2.bb
@@ -4,7 +4,7 @@ inherit ros_component
 DESCRIPTION = "ROS 2.0 driver for Xsens MTi IMU sensors"
 HOMEPAGE = "https://github.com/xsenssupport/Xsens_MTi_ROS_Driver_and_Ntrip_Client"
 LICENSE = "BSD-3-Clause"
-LIC_FILES_CHKSUM = "file://${S}/LICENSE.txt;md5=eafe7ba0ab1f08e996b4dcf42d0b8141"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=eafe7ba0ab1f08e996b4dcf42d0b8141"
 
 ROS_CN = "xsens_mti_ros2_driver"
 ROS_BPN = "xsens_mti_ros2_driver"
@@ -70,7 +70,9 @@ DEPENDS += "${ROS_EXPORT_DEPENDS} ${ROS_BUILDTOOL_EXPORT_DEPENDS}"
 RDEPENDS:${PN} += "${ROS_EXEC_DEPENDS}"
 
 ROS_BRANCH ?= "branch=ros2"
-SRC_URI = "git://github.com/xsenssupport/Xsens_MTi_ROS_Driver_and_Ntrip_Client.git;${ROS_BRANCH};protocol=https"
+SRC_URI = "git://github.com/xsenssupport/Xsens_MTi_ROS_Driver_and_Ntrip_Client.git;${ROS_BRANCH};protocol=https \
+           file://0001-Increase-XdaCallback-max-buffer-size-to-32.patch \
+"
 SRCREV = "d6b87ecf63297b814a4084b95a7b5daf0713be62"
 
 # The upstream repository ships two ROS 2 packages under src/: xsens_mti_ros2_driver
@@ -80,4 +82,4 @@ S = "${UNPACKDIR}/${BP}/src/xsens_mti_ros2_driver"
 
 ROS_BUILD_TYPE = "ament_cmake"
 
-inherit ros_${ROS_BUILD_TYPE}
+inherit ros_${ROS_BUILD_TYPE} robotics-package


### PR DESCRIPTION
# Description
Backport of #328 to `wrynose`.