### PR TITLE
ci(automation): update the commit id from meta-qcom (wrynose): 30134495036

### DIFF
--- a/ci/base.lock.yml
+++ b/ci/base.lock.yml
@@ -3,7 +3,7 @@ header:
 overrides:
     repos:
         oe-core:
-            commit: 5d1aa5c806c061a2994f4decb59016610f093213
+            commit: c2746a4a165fd99c2d1aafed17533555787f37ce
         meta-lts-mixins:
             commit: 6ad95d00531b32ec01792ab496718943dc95277b
         bitbake:
@@ -11,7 +11,7 @@ overrides:
         meta-arm:
             commit: caa36c53f796beb25d9b9f58b1b7a492e9987e15
         meta-openembedded:
-            commit: 100027977216601000cbefc42c2ff6cf667e7b5e
+            commit: d97b5602d7f64422c94b7311466cda7f6b1962d5
         meta-virtualization:
             commit: 781735b97ae5013cacabbecd38e6da6b510cf3fb
         meta-audioreach:

--- a/ci/qcom-robotics-distro.yml
+++ b/ci/qcom-robotics-distro.yml
@@ -10,6 +10,7 @@ repos:
     branch: wrynose
   meta-qcom:
     url: https://github.com/qualcomm-linux/meta-qcom
+    commit: 475163210eb1472d48776c91cf3bb95d8e5a63c1
   oe-core:
     url: https://github.com/openembedded/openembedded-core
     layers:
@@ -18,6 +19,7 @@ repos:
       fix-BSD-license-missing:
         repo: meta-qcom-robotics-sdk
         path: patches/Initial-commit-of-license.patch
+    commit: c2746a4a165fd99c2d1aafed17533555787f37ce
   meta-ros:
     url: https://github.com/ros/meta-ros.git
     branch: wrynose
@@ -42,6 +44,8 @@ repos:
         repo: meta-qcom-robotics-sdk
         path: patches/0001-fix-remove-bbappend-and-patch-for-rosbag2-compressio.patch
     commit: c671acf8a948e22a614a6d6d1dcf18bdf4113df5
+  meta-qcom-distro:
+    commit: b92e0f147ec663aa12d350b7364a24b3a4c35598
 local_conf_header:
   resource_limitation: '# Capture the count of cpu cores available from the host.
 


### PR DESCRIPTION
CRs-Fixed: 4623155

## Auto-update from meta-qcom Nightly Build (wrynose)

This pull request automatically updates the repository commits from the latest meta-qcom wrynose nightly build.

**Build Details:**
- meta-qcom nightly build url: https://github.com/qualcomm-linux/meta-qcom/actions/runs/30134495036
- Check and download actions url: https://github.com/TengFan-QC/meta-qcom-robotics-sdk/actions/runs/30224154562
- Timestamp: Sun Jul 26 22:57:14 UTC 2026