### PR TITLE
feat: enable chrony for robotics time sync features

### DIFF
--- a/recipes-products/images/qcom-robotics-image.bb
+++ b/recipes-products/images/qcom-robotics-image.bb
@@ -19,6 +19,8 @@ CORE_IMAGE_BASE_INSTALL += "            \
     packagegroup-qcom-ros2              \
     packagegroup-robotics-opensource    \
     qirp-sdk                            \
+    chrony                              \
+    chronyc                             \
 "
 
 ROOTFS_SYMLINK_PAIRS = "\


### PR DESCRIPTION
CRs-Fixed: 

Motivation:
Enable chrony in robotics images so robotics SDK performance tests, including localization and navigation, can meet the <=10ms time sync coverage requirement.

Impact:
Users will be able to rely on chrony for millisecond-level time synchronization.