### PR TITLE
ci(automation): update kas config from meta-qcom (master)

### DIFF
--- a/ci/base.lock.yml
+++ b/ci/base.lock.yml
@@ -23,4 +23,4 @@ overrides:
         meta-dpdk:
             commit: ded70edc0937d939596a0c38b737af59afbb5e7b
         meta-ai:
-            commit: c6bd686178d1dcf3b9b4c859058428ede406f7d1
+            commit: 60e38e2015f19058b467febd044f49bf70c4528f

--- a/ci/qcom-robotics-distro.yml
+++ b/ci/qcom-robotics-distro.yml
@@ -10,11 +10,11 @@ repos:
     branch: main
   meta-qcom:
     url: https://github.com/qualcomm-linux/meta-qcom
-    commit: a1978c6c3e4f6e5fd0cd90dfbea3f130210818f8
+    commit: 36d23fedc4c84f2dee486857fc917f866506d047
   meta-qcom-distro:
     url: https://github.com/qualcomm-linux/meta-qcom-distro
     branch: main
-    commit: 5a9bc8bf794cd857ad1986d4c73341ad98b42c48
+    commit: 0fadc6b05fbacbbf11d0ff2b35f12491e196ba24
   oe-core:
     url: https://github.com/openembedded/openembedded-core
     layers:
@@ -23,7 +23,7 @@ repos:
       fix-BSD-license-missing:
         repo: meta-qcom-robotics-sdk
         path: patches/Initial-commit-of-license.patch
-    commit: 31edc0b82a3dc7b1dd0338da4a8d0d8f5a1dc138
+    commit: 62d2381bdee1cebb5924f8594f8a9994083d4f7d
   meta-ros:
     url: https://github.com/ros/meta-ros.git
     branch: master
@@ -94,6 +94,5 @@ local_conf_header:
     PARALLEL_MAKE ?= "-j ${THREAD_COUNT} -l ${THREAD_COUNT}"
 
     '
-
 distro: qcom-robotics-ros2-jazzy
 target: qcom-robotics-image

--- a/conf/distro/include/qcom-robotics-sdk.inc
+++ b/conf/distro/include/qcom-robotics-sdk.inc
@@ -46,3 +46,7 @@ TOOLCHAIN_TARGET_TASK:append = " ${ROS_SDK_TARGET_PACKAGES}"
 # SDK target sysroot. sed provides /bin/sed (via RPROVIDES for usrmerge compat)
 # but is not in the image. Add it explicitly to the SDK target package set.
 TOOLCHAIN_TARGET_TASK:append = " sed"
+
+# protobuf-camx recipe was removed from meta-qcom; replace with nativesdk-protobuf-compiler
+TOOLCHAIN_HOST_TASK:remove = "nativesdk-protobuf-camx-compiler"
+TOOLCHAIN_HOST_TASK:append = " nativesdk-protobuf-compiler"

--- a/recipes-bbappends/recipe-core/packagegroups/packagegroup-core-tools-profile.bbappend
+++ b/recipes-bbappends/recipe-core/packagegroups/packagegroup-core-tools-profile.bbappend
@@ -3,3 +3,9 @@
 # in kernel 7.1 (commits f2e388a019e4, bd803783dfa7, and others).
 # Exclude lttng-modules from the iq-9075-evk build which uses kernel 7.1.
 LTTNGTOOLS:armv8-2a = "lttng-tools"
+
+# Also remove from SDK RDEPENDS so do_populate_sdk does not trigger lttng-modules do_compile.
+# BAD_RECOMMENDATIONS only suppresses rootfs installation; SDK packaging resolves RDEPENDS
+# independently and would otherwise pull lttng-modules into the SDK dependency graph.
+RDEPENDS:${PN}:remove:armv8-2a = "lttng-modules"
+


### PR DESCRIPTION
Auto-update kas config from meta-qcom nightly build

meta-qcom nightly build: https://github.com/qualcomm-linux/meta-qcom/actions/runs/31344960860

Actions run url: https://github.com/TengFan-QC/meta-qcom-robotics-sdk/actions/runs/31362230907

Timestamp: Mon Aug 10 06:30:54 UTC 2026