### PR TITLE
ci(automation): update kas config from meta-qcom (wrynose): 30591306265

### DIFF
--- a/ci/qcom-robotics-distro.yml
+++ b/ci/qcom-robotics-distro.yml
@@ -10,7 +10,7 @@ repos:
     branch: wrynose
   meta-qcom:
     url: https://github.com/qualcomm-linux/meta-qcom
-    commit: 475163210eb1472d48776c91cf3bb95d8e5a63c1
+    commit: 08c6fad437408d3f38afdd9b82dd6b1fc3a7f872
   oe-core:
     url: https://github.com/openembedded/openembedded-core
     layers:


### PR DESCRIPTION
CRs-Fixed: 4649395

## Auto-update kas config from meta-qcom nightly build (wrynose)

This pull request automatically updates kas config from the latest meta-qcom wrynose nightly build.

**Build Details:**
- meta-qcom nightly build url: https://github.com/qualcomm-linux/meta-qcom/actions/runs/30591306265
- Check and download actions url: https://github.com/TengFan-QC/meta-qcom-robotics-sdk/actions/runs/31362752136
- Timestamp: Mon Aug 10 06:41:00 UTC 2026