### PR TITLE
ci(automation): update kas config from meta-qcom (master): 31344960860

### DIFF
--- a/ci/base.lock.yml
+++ b/ci/base.lock.yml
@@ -23,4 +23,4 @@ overrides:
         meta-dpdk:
             commit: ded70edc0937d939596a0c38b737af59afbb5e7b
         meta-ai:
-            commit: c6bd686178d1dcf3b9b4c859058428ede406f7d1
+            commit: 60e38e2015f19058b467febd044f49bf70c4528f

--- a/ci/qcom-robotics-distro.yml
+++ b/ci/qcom-robotics-distro.yml
@@ -10,11 +10,11 @@ repos:
     branch: main
   meta-qcom:
     url: https://github.com/qualcomm-linux/meta-qcom
-    commit: a1978c6c3e4f6e5fd0cd90dfbea3f130210818f8
+    commit: 36d23fedc4c84f2dee486857fc917f866506d047
   meta-qcom-distro:
     url: https://github.com/qualcomm-linux/meta-qcom-distro
     branch: main
-    commit: 5a9bc8bf794cd857ad1986d4c73341ad98b42c48
+    commit: 0fadc6b05fbacbbf11d0ff2b35f12491e196ba24
   oe-core:
     url: https://github.com/openembedded/openembedded-core
     layers:
@@ -23,7 +23,7 @@ repos:
       fix-BSD-license-missing:
         repo: meta-qcom-robotics-sdk
         path: patches/Initial-commit-of-license.patch
-    commit: 31edc0b82a3dc7b1dd0338da4a8d0d8f5a1dc138
+    commit: 62d2381bdee1cebb5924f8594f8a9994083d4f7d
   meta-ros:
     url: https://github.com/ros/meta-ros.git
     branch: master
@@ -94,6 +94,5 @@ local_conf_header:
     PARALLEL_MAKE ?= "-j ${THREAD_COUNT} -l ${THREAD_COUNT}"
 
     '
-
 distro: qcom-robotics-ros2-jazzy
 target: qcom-robotics-image

--- a/conf/distro/include/qcom-robotics-sdk.inc
+++ b/conf/distro/include/qcom-robotics-sdk.inc
@@ -46,3 +46,7 @@ TOOLCHAIN_TARGET_TASK:append = " ${ROS_SDK_TARGET_PACKAGES}"
 # SDK target sysroot. sed provides /bin/sed (via RPROVIDES for usrmerge compat)
 # but is not in the image. Add it explicitly to the SDK target package set.
 TOOLCHAIN_TARGET_TASK:append = " sed"
+
+# protobuf-camx recipe was removed from meta-qcom; replace with nativesdk-protobuf-compiler
+TOOLCHAIN_HOST_TASK:remove = "nativesdk-protobuf-camx-compiler"
+TOOLCHAIN_HOST_TASK:append = " nativesdk-protobuf-compiler"

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -24,9 +24,3 @@ ROS_UNRESOLVED_DEP-libnanoflann-dev:forcevariable = "nanoflann"
 
 ROBIOTICS_LAYER_DIR = "${LAYERDIR}"
 COMMON_LICENSE_DIR = "${COREBASE}/meta/files/common-licenses"
-
-# lttng-modules 2.14.4 is incompatible with Linux kernel 7.1 (trace API changes
-# in hrtimer_start, hrtimer_expire_entry, mm_vmscan, and mm_shrink_slab).
-# The iq-9075-evk uses kernel 7.1. Exclude lttng-modules from the image to
-# prevent build failures while still allowing lttng-tools to be installed.
-BAD_RECOMMENDATIONS += "lttng-modules"

--- a/recipes-bbappends/recipe-core/packagegroups/packagegroup-core-tools-profile.bbappend
+++ b/recipes-bbappends/recipe-core/packagegroups/packagegroup-core-tools-profile.bbappend
@@ -1,5 +1,0 @@
-# lttng-modules 2.14.4 is incompatible with Linux kernel >= 7.1.
-# The vmscan, shrink_slab, and hrtimer trace event APIs changed significantly
-# in kernel 7.1 (commits f2e388a019e4, bd803783dfa7, and others).
-# Exclude lttng-modules from the iq-9075-evk build which uses kernel 7.1.
-LTTNGTOOLS:armv8-2a = "lttng-tools"

--- a/recipes-bbappends/recipe-kernel/lttng/lttng-tools_%.bbappend
+++ b/recipes-bbappends/recipe-kernel/lttng/lttng-tools_%.bbappend
@@ -1,0 +1,10 @@
+# lttng-modules 2.14.4+ is incompatible with the Linux kernel >= 7.1 used by
+# iq-9075-evk (vmscan/shrink_slab/hrtimer trace event API changes).
+#
+# lttng-tools itself builds fine, but its -ptest package hard-RDEPENDS on
+# ${LTTNGMODULES} (see recipes-kernel/lttng/lttng-tools_*.bb), which pulls
+# lttng-modules back into the dependency graph and triggers its compile.
+# BAD_RECOMMENDATIONS cannot help here because it only filters RRECOMMENDS,
+# not RDEPENDS, so clear the variable to drop lttng-modules from every path
+# (both the packagegroup RDEPENDS and the -ptest RDEPENDS).
+LTTNGMODULES = ""


### PR DESCRIPTION
CRs-Fixed: 4649394

Auto-update kas config from meta-qcom nightly build (master)
This pull request automatically updates kas config from the latest meta-qcom master nightly build.

Build Details:

meta-qcom nightly build url: https://github.com/qualcomm-linux/meta-qcom/actions/runs/31344960860
Check and download actions url: https://github.com/TengFan-QC/meta-qcom-robotics-sdk/actions/runs/31950895718
Timestamp: Sun Aug 16 13:51:03 UTC 2026

Other changes:
-  qcom-multimedia-proprietary-image.bb appends nativesdk-protobuf-camx-compiler
    to TOOLCHAIN_HOST_TASK, but the protobuf-camx recipe has been removed from
    meta-qcom. meta-qcom already applies a workaround for sibling images via
    qcom-common-binary.inc, but qcom-robotics-proprietary-image was not covered.
    Fix by explicitly removing nativesdk-protobuf-camx-compiler and substituting
    nativesdk-protobuf-compiler in qcom-robotics-proprietary-image.bb.
-  lttng-tools-ptest hard-RDEPENDS on ${LTTNGMODULES}, which pulled
    lttng-modules back into the dependency graph and triggered its
    compile. Clear LTTNGMODULES in a lttng-tools_%.bbappend to drop
    lttng-modules from every path while keeping lttng-tools (and
    lttng-ust) in the image.