### PR TITLE
fix(qrb-ros-audio-service): fix capture publish latency too high and latency log not print

### DIFF
--- a/recipes/qrb-ros-audio-service/files/0001-fix-record-volume-too-low.patch
+++ b/recipes/qrb-ros-audio-service/files/0001-fix-record-volume-too-low.patch
@@ -1,17 +1,16 @@
-From 00747de8358ec7bab4c07749f198d2da7bf7416b Mon Sep 17 00:00:00 2001
+From 46c04ad1916002c6086937b71ddaa24accd9fb80 Mon Sep 17 00:00:00 2001
 From: Ronghui Zhu <ronghuiz@qti.qualcomm.com>
 Date: Tue, 21 Apr 2026 17:43:06 +0800
 Subject: [PATCH] fix: record volume too low
 
 Upstream-Status: Inappropriate [platform-specific workaround]
-
 ---
  .../include/qrb_audio_common_lib/audio_common.hpp            | 1 +
  qrb_audio_common_lib/src/capture_stream.cpp                  | 5 +++--
  2 files changed, 4 insertions(+), 2 deletions(-)
 
 diff --git a/qrb_audio_common_lib/include/qrb_audio_common_lib/audio_common.hpp b/qrb_audio_common_lib/include/qrb_audio_common_lib/audio_common.hpp
-index 2068c04..5ab31cb 100644
+index 2068c04..2e13bcf 100644
 --- a/qrb_audio_common_lib/include/qrb_audio_common_lib/audio_common.hpp
 +++ b/qrb_audio_common_lib/include/qrb_audio_common_lib/audio_common.hpp
 @@ -26,6 +26,7 @@ namespace audio_common_lib
@@ -23,11 +22,11 @@ index 2068c04..5ab31cb 100644
  #define LOG_ERROR (0x1)
  #define LOG_INFO (0x2)
 diff --git a/qrb_audio_common_lib/src/capture_stream.cpp b/qrb_audio_common_lib/src/capture_stream.cpp
-index 0976971..f800338 100644
+index a984714..bc662fb 100644
 --- a/qrb_audio_common_lib/src/capture_stream.cpp
 +++ b/qrb_audio_common_lib/src/capture_stream.cpp
-@@ -64,7 +64,8 @@ int CaptureStream::start_stream()
-   buffer_attr.fragsize = buffer_attr.tlength = (uint32_t)-1;
+@@ -67,7 +67,8 @@ int CaptureStream::start_stream()
+   buffer_attr.tlength = (uint32_t)-1;
    buffer_attr.minreq = (uint32_t)-1;
  
 -  pa_cvolume_set(&volume, m_sample_spec->channels, PA_VOLUME_NORM * mvolume / STREAM_VOL_MAX);
@@ -36,13 +35,10 @@ index 0976971..f800338 100644
  
    if (pa_stream_connect_record(stream, /*device*/ nullptr, &buffer_attr, flags)) {
      LOGE("pa_stream_connect_playback() failed: %s",
-@@ -180,4 +181,4 @@ void CaptureStream::stream_data_callback(pa_stream * stream, size_t length, void
+@@ -183,4 +184,4 @@ void CaptureStream::stream_data_callback(pa_stream * stream, size_t length, void
  }
  
  }  // namespace audio_common_lib
 -}  // namespace qrb
 \ No newline at end of file
 +}  // namespace qrb
--- 
-2.34.1
-

--- a/recipes/qrb-ros-audio-service/qrb-audio-common-lib_1.0.4.bb
+++ b/recipes/qrb-ros-audio-service/qrb-audio-common-lib_1.0.4.bb
@@ -7,7 +7,7 @@ SECTION = "devel"
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://../LICENSE;md5=68c28a8a26024c85c589d0de638520b6"
 
-PV = "1.0.3"
+PV = "1.0.4"
 
 DEPENDS = "glog gflags"
 
@@ -15,7 +15,7 @@ SRC_URI = "git://github.com/quic-qrb-ros/qrb_ros_audio_service.git;protocol=http
            file://0001-fix-record-volume-too-low.patch;striplevel=2 \
            "
 
-SRCREV = "7a6e720cbd0a649432461a41069e880647c5c2be"
+SRCREV = "63a46f4c87c34a113912515c1ce14fa747601151"
 S = "${UNPACKDIR}/${BP}/qrb_audio_common_lib"
 
 DEPENDS += " \

--- a/recipes/qrb-ros-audio-service/qrb-audio-service-lib_1.0.4.bb
+++ b/recipes/qrb-ros-audio-service/qrb-audio-service-lib_1.0.4.bb
@@ -7,13 +7,13 @@ SECTION = "devel"
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://../LICENSE;md5=68c28a8a26024c85c589d0de638520b6"
 
-PV = "1.0.3"
+PV = "1.0.4"
 
 DEPENDS = "glog gflags"
 
 SRC_URI = "git://github.com/quic-qrb-ros/qrb_ros_audio_service.git;protocol=https;branch=stable/1.0.3"
 
-SRCREV = "7a6e720cbd0a649432461a41069e880647c5c2be"
+SRCREV = "63a46f4c87c34a113912515c1ce14fa747601151"
 S = "${UNPACKDIR}/${BP}/qrb_audio_manager"
 
 DEPENDS += " \

--- a/recipes/qrb-ros-audio-service/qrb-ros-audio-common_1.0.4.bb
+++ b/recipes/qrb-ros-audio-service/qrb-ros-audio-common_1.0.4.bb
@@ -42,9 +42,9 @@ DEPENDS += "${ROS_EXPORT_DEPENDS} ${ROS_BUILDTOOL_EXPORT_DEPENDS}"
 RDEPENDS:${PN} += "${ROS_EXEC_DEPENDS}"
 
 SRC_URI = "git://github.com/quic-qrb-ros/qrb_ros_audio_service.git;protocol=https;branch=stable/1.0.3"
-SRCREV = "7a6e720cbd0a649432461a41069e880647c5c2be"
+SRCREV = "63a46f4c87c34a113912515c1ce14fa747601151"
 S = "${UNPACKDIR}/${BP}/qrb_ros_audio_common"
-PV = "1.0.3"
+PV = "1.0.4"
 
 ROS_BUILD_TYPE = "ament_cmake"
 

--- a/recipes/qrb-ros-audio-service/qrb-ros-audio-service_1.0.4.bb
+++ b/recipes/qrb-ros-audio-service/qrb-ros-audio-service_1.0.4.bb
@@ -44,9 +44,9 @@ DEPENDS += "${ROS_EXPORT_DEPENDS} ${ROS_BUILDTOOL_EXPORT_DEPENDS}"
 RDEPENDS:${PN} += "${ROS_EXEC_DEPENDS}"
 
 SRC_URI = "git://github.com/quic-qrb-ros/qrb_ros_audio_service.git;protocol=https;branch=stable/1.0.3"
-SRCREV = "7a6e720cbd0a649432461a41069e880647c5c2be"
+SRCREV = "63a46f4c87c34a113912515c1ce14fa747601151"
 S = "${UNPACKDIR}/${BP}/qrb_ros_audio_service"
-PV = "1.0.3"
+PV = "1.0.4"
 
 ROS_BUILD_TYPE = "ament_cmake"
 


### PR DESCRIPTION
CRs-Fixed: 4628761 4640902

Motivation:
- Fix capture publish latency too high.
- Fix latency log not print.

Impact:
Latency log can be enable by "ros2 param set /audio_service enable_latency_log true".
Capture stream frag size set to 20ms.