### PR TITLE
fix: fix input tensor blocking in depth estimation

### DIFF
--- a/recipes/qrb-ros-samples/sample-depth-estimation_1.0.2.bb
+++ b/recipes/qrb-ros-samples/sample-depth-estimation_1.0.2.bb
@@ -9,7 +9,7 @@ ROS_BPN = "sample_depth_estimation"
 
 SRC_URI = "git://github.com/qualcomm-qrb-ros/qrb_ros_samples.git;protocol=https;branch=stable-sample_depth_estimation/1.0.0"
 
-SRCREV = "315c7813ffed90222fbf7230f1ae2f85bdaf9613"
+SRCREV = "8365d9e72837e74eccae1778c5b6253b5bc37660"
 
 ROS_BUILD_DEPENDS = " \
 "


### PR DESCRIPTION
CRs-Fixed: 4646386

Motivation:
- Fix depth estimation runtime blocking that occurs when the NN inference node initializes after the input tensor has already been published.

Impact:
- Sample depth estimation code base update to latest on stable branch.
- Sample-depth-estimation PV update to 1.0.2.