### PR TITLE
ci(automation): update kas config from meta-qcom (master): 32433212746

### DIFF
--- a/ci/base.lock.yml
+++ b/ci/base.lock.yml
@@ -3,24 +3,24 @@ header:
 overrides:
     repos:
         oe-core:
-            commit: 62d2381bdee1cebb5924f8594f8a9994083d4f7d
+            commit: d51c6e87a10c7c75a692ca86b71af9a818026ecb
         bitbake:
-            commit: 3a99c26fa581d70ed67bd08a5e0e0d0b18369a7c
+            commit: 7a3cb0d55e3698e883a9ff8491febc9d155482ca
         meta-arm:
-            commit: 28606c721503b70e8343968731a24260cfe985bc
+            commit: 170b7e2a1c264c2f6360b4e298b16542196601af
         meta-openembedded:
-            commit: dc0ccaa27311b3379749ecf44f98c0b5e249902e
+            commit: ea7c7c4f2e21a0aadb53d1691de6d5a85dc11a8e
         meta-virtualization:
-            commit: 022f4356d4a9b389f51472d40a9330aa59f6bb9a
+            commit: cbaa5b92b046a13585105713166c886cdfd5de33
         meta-audioreach:
-            commit: b5a382aba0e5b1e4cfbd9f36256ea46e0d4cf002
+            commit: 3f673ee6f52bfeda69205078a99e89cd501015b4
         meta-selinux:
             commit: 7351443c6579671bcf048817438f1740ad23eaab
         meta-updater:
-            commit: fff4a58a057c26ec0a2067ea5f32acd75ef7add4
+            commit: 94ef61e04dc69e02874bdb8645de615d56f0b6a2
         meta-security:
             commit: 226839ac408223f8041cde1b1d8b762d6fbc8050
         meta-dpdk:
-            commit: ded70edc0937d939596a0c38b737af59afbb5e7b
+            commit: 6a59b0cd21084e33feb53b4f2d1310e49e1d4a83
         meta-ai:
-            commit: c6bd686178d1dcf3b9b4c859058428ede406f7d1
+            commit: 3511d6c9669683fc232211eb72e1549d6db6e660

--- a/ci/qcom-distro.yml
+++ b/ci/qcom-distro.yml
@@ -37,6 +37,13 @@ repos:
 
   meta-selinux:
     url: https://git.yoctoproject.org/meta-selinux
+    patches:
+      libsepol-nativesdk:
+        repo: meta-qcom
+        path: patches/selinux/0001-libsepol-enable-nativesdk.patch
+      libselinux-nativesdk:
+        repo: meta-qcom
+        path: patches/selinux/0002-libselinux-enable-nativesdk.patch
 
   meta-updater:
     url: https://github.com/uptane/meta-updater

--- a/ci/qcom-robotics-distro.yml
+++ b/ci/qcom-robotics-distro.yml
@@ -10,11 +10,11 @@ repos:
     branch: main
   meta-qcom:
     url: https://github.com/qualcomm-linux/meta-qcom
-    commit: a1978c6c3e4f6e5fd0cd90dfbea3f130210818f8
+    commit: 086b40abd4db0463e1bccb0802c1544f9c5ec988
   meta-qcom-distro:
     url: https://github.com/qualcomm-linux/meta-qcom-distro
     branch: main
-    commit: 5a9bc8bf794cd857ad1986d4c73341ad98b42c48
+    commit: 54961938da5855b4ae6809c0eb4ddbdfb6b21f4f
   oe-core:
     url: https://github.com/openembedded/openembedded-core
     layers:
@@ -23,7 +23,7 @@ repos:
       fix-BSD-license-missing:
         repo: meta-qcom-robotics-sdk
         path: patches/Initial-commit-of-license.patch
-    commit: 31edc0b82a3dc7b1dd0338da4a8d0d8f5a1dc138
+    commit: d51c6e87a10c7c75a692ca86b71af9a818026ecb
   meta-ros:
     url: https://github.com/ros/meta-ros.git
     branch: master
@@ -94,6 +94,5 @@ local_conf_header:
     PARALLEL_MAKE ?= "-j ${THREAD_COUNT} -l ${THREAD_COUNT}"
 
     '
-
 distro: qcom-robotics-ros2-jazzy
 target: qcom-robotics-image


### PR DESCRIPTION
## Auto-update kas config from meta-qcom nightly build (master)

This pull request automatically updates kas config from the latest meta-qcom master nightly build.

**Build Details:**
- meta-qcom nightly build url: https://github.com/qualcomm-linux/meta-qcom/actions/runs/32433212746
- Check and download actions url: (local run of the meta-layers-update skill on szebldarm02)
- Timestamp: Fri Aug 21 06:51:16 AM UTC 2026