### PR TITLE
ci(automation): update kas config from meta-qcom (wrynose): 32429086783

### DIFF
--- a/ci/base.lock.yml
+++ b/ci/base.lock.yml
@@ -3,19 +3,19 @@ header:
 overrides:
     repos:
         oe-core:
-            commit: c2746a4a165fd99c2d1aafed17533555787f37ce
+            commit: f09a0f28aeb54ddd90415dd458338e1565bb5a49
         meta-lts-mixins:
             commit: 6ad95d00531b32ec01792ab496718943dc95277b
         bitbake:
-            commit: acfe02fa38b5da9e6a36c6cedcf91d4fcbefbfbd
+            commit: fae9db3168dbff1b8c76fe9c6726a9687ff97514
         meta-arm:
-            commit: caa36c53f796beb25d9b9f58b1b7a492e9987e15
+            commit: 0979b80429099f1a42dc0026c8c466cee780bc74
         meta-openembedded:
-            commit: d97b5602d7f64422c94b7311466cda7f6b1962d5
+            commit: 6bf0d8ad57b33950bab4c7f6c037e1ccb6f6e2eb
         meta-virtualization:
-            commit: 781735b97ae5013cacabbecd38e6da6b510cf3fb
+            commit: ff03b1e118c4788f17d7ae45b820b00e3194634a
         meta-audioreach:
-            commit: bb3f812fa666fa1a03279b77e2c75f529ee9d797
+            commit: 3f673ee6f52bfeda69205078a99e89cd501015b4
         meta-selinux:
             commit: 1c3a699f363167571ab39fecb0fe6f56691a4e20
         meta-updater:
@@ -23,4 +23,4 @@ overrides:
         meta-security:
             commit: c0d1d6200e7a84c39fb940cb1f22aad4b0b3d808
         meta-dpdk:
-            commit: ded70edc0937d939596a0c38b737af59afbb5e7b
+            commit: 6a59b0cd21084e33feb53b4f2d1310e49e1d4a83

--- a/ci/qcom-robotics-distro.yml
+++ b/ci/qcom-robotics-distro.yml
@@ -10,7 +10,7 @@ repos:
     branch: wrynose
   meta-qcom:
     url: https://github.com/qualcomm-linux/meta-qcom
-    commit: 08c6fad437408d3f38afdd9b82dd6b1fc3a7f872
+    commit: f415a09a64e1a282fe9ca1efa47b911caaffe1b8
   oe-core:
     url: https://github.com/openembedded/openembedded-core
     layers:
@@ -19,7 +19,7 @@ repos:
       fix-BSD-license-missing:
         repo: meta-qcom-robotics-sdk
         path: patches/Initial-commit-of-license.patch
-    commit: c2746a4a165fd99c2d1aafed17533555787f37ce
+    commit: f09a0f28aeb54ddd90415dd458338e1565bb5a49
   meta-ros:
     url: https://github.com/ros/meta-ros.git
     branch: wrynose
@@ -45,7 +45,7 @@ repos:
         path: patches/0001-fix-remove-bbappend-and-patch-for-rosbag2-compressio.patch
     commit: c671acf8a948e22a614a6d6d1dcf18bdf4113df5
   meta-qcom-distro:
-    commit: b92e0f147ec663aa12d350b7364a24b3a4c35598
+    commit: 55aae963e53a82c637fcd4f9ed58108252b0346c
 local_conf_header:
   resource_limitation: '# Capture the count of cpu cores available from the host.
 

--- a/recipes-bbappends/recipe-ros/ompl/ompl_%.bbappend
+++ b/recipes-bbappends/recipe-ros/ompl/ompl_%.bbappend
@@ -25,6 +25,19 @@ do_install:append() {
                     # Replace remaining STAGING_DIR_HOST paths (remove them)
                     sed -i "s|${STAGING_DIR_HOST}||g" "$file"
                     ;;
+                *.py)
+                    # ompl ships demo/benchmark scripts (share/ompl/demos/*.py,
+                    # bin/ompl_benchmark_statistics.py) whose interpreter line is
+                    # rewritten to the build-time native python
+                    # (${TMPDIR}/.../hosttools/python3). That absolute build path
+                    # trips both [buildpaths] and [file-rdeps] QA. Normalise the
+                    # first-line shebang to the portable form; only touch line 1
+                    # so script bodies are left untouched.
+                    if head -1 "$file" | grep -q "^#!.*python"; then
+                        bbnote "Fixing python shebang: $file"
+                        sed -i "1s|^#!.*python[0-9.]*|#!/usr/bin/env python3|" "$file"
+                    fi
+                    ;;
             esac
         done
     fi


### PR DESCRIPTION
CRs-Fixed: 4649395

## Auto-update kas config from meta-qcom nightly build (wrynose)

This pull request automatically updates kas config from the latest meta-qcom wrynose nightly build.

**Build Details:**
- meta-qcom nightly build url: https://github.com/qualcomm-linux/meta-qcom/actions/runs/32429086783
- Check and download actions url: (local run of the meta-layers-update skill on tieqluo14)
- Timestamp: Mon Aug 24 03:33:26 AM UTC 2026

Motivation: 
ompl's demo and benchmark python scripts get their shebang rewritten to an
absolute build-time hosttools python3 path during install, which fails the
[buildpaths] and [file-rdeps] QA checks.
Impact: 
do_install:append() in ompl_%.bbappend now rewrites the first line of any
*.py file to a portable "#!/usr/bin/env python3" shebang, resolving the QA
warnings without touching the rest of the script content.