### PR TITLE
fix: add control loop configurable parameter and update doc

### DIFF
--- a/recipes/qrb-ros-samples/sample-remote-assistant_0.0.1.bb
+++ b/recipes/qrb-ros-samples/sample-remote-assistant_0.0.1.bb
@@ -12,7 +12,7 @@ ROS_CN = "simulation_remote_assistant"
 ROS_BPN = "simulation_remote_assistant"
 
 SRC_URI = "git://github.com/qualcomm-qrb-ros/qrb_ros_samples.git;protocol=https;branch=stable-simulation_remote_assistant/1.0.0"
-SRCREV = "b7fd87ee8ccf773a05647cde96a6ea22217f8ef5"
+SRCREV = "8ec124c7ffa2804360b7fd5bbd84a440cf1117e1"
 
 ROS_BUILD_DEPENDS = " \
    python3-setuptools-native \


### PR DESCRIPTION
CRs-Fixed: 4655028

Motivation:

The control loop checks the FORWARD/TURN target once per tick, so theovershoot is roughly speed * period. The period was hardcoded to 0.2 s, so on machines where the loop or the /odom callback runs slower the robot overshoots turns and can hit a wall while mapping.

Impact:

Without this change, the control loop will not parameter configurable and block the test 