### PR TITLE
ci(automation): update kas config from meta-qcom (master): 29174562861

### DIFF
--- a/ci/base.lock.yml
+++ b/ci/base.lock.yml
@@ -3,24 +3,24 @@ header:
 overrides:
     repos:
         oe-core:
-            commit: 62d2381bdee1cebb5924f8594f8a9994083d4f7d
+            commit: f810998ac90f7a3e20e26555f39d754b16ce8b69
         bitbake:
-            commit: 3a99c26fa581d70ed67bd08a5e0e0d0b18369a7c
+            commit: 7e3489ab3ec39b2dcf4e50eff54d36d42e5a7307
         meta-arm:
-            commit: 28606c721503b70e8343968731a24260cfe985bc
+            commit: 847af9c082cc190b3781f101200a9403426e481b
         meta-openembedded:
-            commit: dc0ccaa27311b3379749ecf44f98c0b5e249902e
+            commit: a7428c96bf97a751ccd5baa63acfa1f5b49f077e
         meta-virtualization:
             commit: 022f4356d4a9b389f51472d40a9330aa59f6bb9a
         meta-audioreach:
-            commit: b5a382aba0e5b1e4cfbd9f36256ea46e0d4cf002
+            commit: c80ebf5be5cc47a1bab1acb4b1987c8cd8b48218
         meta-selinux:
             commit: 7351443c6579671bcf048817438f1740ad23eaab
         meta-updater:
-            commit: fff4a58a057c26ec0a2067ea5f32acd75ef7add4
+            commit: f0e1ccafaa877d2781ed953236981dac57439dc8
         meta-security:
             commit: 226839ac408223f8041cde1b1d8b762d6fbc8050
         meta-dpdk:
             commit: ded70edc0937d939596a0c38b737af59afbb5e7b
         meta-ai:
-            commit: 60e38e2015f19058b467febd044f49bf70c4528f
+            commit: 6e46e36155ff181fb45d9cb5d290d9a3480bf6f7

--- a/ci/qcom-robotics-distro.yml
+++ b/ci/qcom-robotics-distro.yml
@@ -10,7 +10,7 @@ repos:
     branch: main
   meta-qcom:
     url: https://github.com/qualcomm-linux/meta-qcom
-    commit: 36d23fedc4c84f2dee486857fc917f866506d047
+    commit: d2dda53767a99880287691c2d8ea1e1dd6f81ae2
   meta-qcom-distro:
     url: https://github.com/qualcomm-linux/meta-qcom-distro
     branch: main
@@ -23,7 +23,7 @@ repos:
       fix-BSD-license-missing:
         repo: meta-qcom-robotics-sdk
         path: patches/Initial-commit-of-license.patch
-    commit: 62d2381bdee1cebb5924f8594f8a9994083d4f7d
+    commit: f810998ac90f7a3e20e26555f39d754b16ce8b69
   meta-ros:
     url: https://github.com/ros/meta-ros.git
     branch: master


### PR DESCRIPTION
## Auto-update kas config from meta-qcom nightly build (master)

This pull request automatically updates kas config from the latest meta-qcom master nightly build.

**Build Details:**
- meta-qcom nightly build url: https://github.com/qualcomm-linux/meta-qcom/actions/runs/29174562861
- Check and download actions url: (local run of the meta-layers-update skill on tieqluo14)
- Timestamp: Wed Aug 26 07:36:59 AM UTC 2026