### PR TITLE
build: add staticdev libs to SDK target task

### DIFF
--- a/conf/distro/include/qcom-robotics-sdk.inc
+++ b/conf/distro/include/qcom-robotics-sdk.inc
@@ -40,12 +40,13 @@ TOOLCHAIN_TARGET_TASK:remove = "qirp-sdk"
 # Add default packages from meta-ros ros-sdk.inc
 TOOLCHAIN_HOST_TASK:append = " ${ROS_SDK_HOST_PACKAGES}"
 
-TOOLCHAIN_TARGET_TASK:append = " ${ROS_SDK_TARGET_PACKAGES}"
-
-# kernel-devsrc's RPM auto-generated Requires:/bin/sed must be satisfied in the
-# SDK target sysroot. sed provides /bin/sed (via RPROVIDES for usrmerge compat)
-# but is not in the image. Add it explicitly to the SDK target package set.
-TOOLCHAIN_TARGET_TASK:append = " sed"
+TOOLCHAIN_TARGET_TASK:append = " \
+    ${ROS_SDK_TARGET_PACKAGES} \
+    sed \
+    fmt-staticdev \
+    octomap-staticdev \
+    osqp-vendor-staticdev \
+"
 
 # protobuf-camx recipe was removed from meta-qcom; replace with nativesdk-protobuf-compiler
 TOOLCHAIN_HOST_TASK:remove = "nativesdk-protobuf-camx-compiler"

--- a/recipes-products/packagegroups/packagegroup-qcom-ros2.bb
+++ b/recipes-products/packagegroups/packagegroup-qcom-ros2.bb
@@ -45,8 +45,6 @@ RDEPENDS:${PN}-extend = "\
     moveit-ros-perception-dev \
     moveit-planners-ompl-dev \
     laser-filters \
-    octomap-staticdev \
-    osqp-vendor-staticdev \
 "
 
 RDEPENDS:${PN}-samples = "\


### PR DESCRIPTION
CRs-Fixed: 4652892

Phenomenon
- The QIR SDK toolchain/sysroot contains incomplete or inconsistent package installations. The CMake export file (fmt-targets.cmake) references libfmt-c.a, but the corresponding static library is missing from the SDK sysroot, causing find_package(fmt) to fail during project configuration.
- Similar issues were also observed with the octomap and octomath libraries, where the generated CMake configuration files reference static libraries that are not included in the SDK toolchain.

Motivation:
- Add fmt-staticdev, octomap-staticdev, and osqp-vendor-staticdev to TOOLCHAIN_TARGET_TASK so the robotics SDK sysroot ships the static libraries needed by out-of-tree consumers. Also drop the duplicate sed append and merge it into the single TOOLCHAIN_TARGET_TASK append list for clarity.
- Remove octomap-staticdev and osqp-vendor-staticdev from packagegroup-qcom-ros2's -extend RDEPENDS since they now come from the SDK target task instead, avoiding duplicate package pulls.

Impact:
- libfmt-c static library add to qir-sdk toolchain.