### PR TITLE
[Backport wrynose] fix(decoder): disable auto-release for dmabuf handle

### DIFF
--- a/recipes/qrb-ros-video/qrb-ros-video_0.1.7.bb
+++ b/recipes/qrb-ros-video/qrb-ros-video_0.1.7.bb
@@ -66,7 +66,7 @@ RDEPENDS:${PN} += "${ROS_EXEC_DEPENDS}"
 SRC_URI = "git://github.com/quic-qrb-ros/qrb_ros_video.git;protocol=https;branch=stable/0.1.7 \
            file://0002-fix-test-add-mp4-extension-fallback-when-discoverer-fail-29.patch;striplevel=2 \
            "
-SRCREV = "3b94a5f4ec6cc498fe4161d010f44f5393030173"
+SRCREV = "bc8382c11a0022a385a41518ea1a431415b78f7d"
 S = "${UNPACKDIR}/${BP}/qrb_ros_video"
 PV = "0.1.7"
 

--- a/recipes/qrb-ros-video/qrb-video-v4l2-lib_0.1.7.bb
+++ b/recipes/qrb-ros-video/qrb-video-v4l2-lib_0.1.7.bb
@@ -16,7 +16,7 @@ SRC_URI = "git://github.com/quic-qrb-ros/qrb_ros_video.git;protocol=https;branch
            file://0001-fix-decoder-defer-output-port-setup-until-source-res.patch;striplevel=2 \
           "
 
-SRCREV = "3b94a5f4ec6cc498fe4161d010f44f5393030173"
+SRCREV = "bc8382c11a0022a385a41518ea1a431415b78f7d"
 S = "${UNPACKDIR}/${BP}/qrb_video_v4l2_lib"
 
 EXTRA_OECMAKE:append = " -DBUILD_TESTING=OFF"


### PR DESCRIPTION
# Description
Backport of #355 to `wrynose`.