### PR TITLE
ci: remove pinned commit hashes for meta-qcom and meta-qcom-distro

### DIFF
--- a/ci/qcom-robotics-distro.yml
+++ b/ci/qcom-robotics-distro.yml
@@ -10,11 +10,9 @@ repos:
     branch: main
   meta-qcom:
     url: https://github.com/qualcomm-linux/meta-qcom
-    commit: 36d23fedc4c84f2dee486857fc917f866506d047
   meta-qcom-distro:
     url: https://github.com/qualcomm-linux/meta-qcom-distro
     branch: main
-    commit: 0fadc6b05fbacbbf11d0ff2b35f12491e196ba24
   oe-core:
     url: https://github.com/openembedded/openembedded-core
     layers:


### PR DESCRIPTION
CRs-Fixed: 
Motivation: 
- Unpin meta-qcom and meta-qcom-distro from fixed commit SHAs in the CI manifest so builds automatically pick up the latest changes on the main branch instead of being locked to an outdated commit.

Impact: 
- Affects CI builds using qcom-robotics-distro.yml — these two repos will now float to the tip of main. No other layers or repos are affected.