### PR TITLE
fix(meta-ros): remove license qa check for meta-ros recipe incompitable license check

### DIFF
--- a/ci/qcom-robotics-distro.yml
+++ b/ci/qcom-robotics-distro.yml
@@ -94,5 +94,8 @@ local_conf_header:
     PARALLEL_MAKE ?= "-j ${THREAD_COUNT} -l ${THREAD_COUNT}"
 
     '
+  license_qa: 'ERROR_QA:remove = "license-format"
+
+    '
 distro: qcom-robotics-ros2-jazzy
 target: qcom-robotics-image


### PR DESCRIPTION
CRs-Fixed: 

## Motivation

- meta-ros has recipes with incompatible license headers. 
- Workaround: use ERROR_QA:remove to bypass the license checks.

## Impact

- Demote `license-format` QA checks from ERROR to WARN to avoid parse failures from meta-ros generated recipes.