### PR TITLE
chore(ci): update meta-ros to f4a5e480 (wrynose)

### DIFF
--- a/ci/qcom-robotics-distro.yml
+++ b/ci/qcom-robotics-distro.yml
@@ -43,7 +43,7 @@ repos:
       remove-rosbag2-compressionn-zstd-bbappend:
         repo: meta-qcom-robotics-sdk
         path: patches/0001-fix-remove-bbappend-and-patch-for-rosbag2-compressio.patch
-    commit: c671acf8a948e22a614a6d6d1dcf18bdf4113df5
+    commit: f4a5e4800a90ae435b5437d895ea4cd894fad53a
   meta-qcom-distro:
     commit: 55aae963e53a82c637fcd4f9ed58108252b0346c
 local_conf_header:


### PR DESCRIPTION
## Summary

Update `meta-ros` commit hash to the latest upstream `wrynose` branch.

| | Commit |
|---|---|
| **Previous** | `c671acf8a948e22a614a6d6d1dcf18bdf4113df5` |
| **New** | `f4a5e4800a90ae435b5437d895ea4cd894fad53a` |

## Motivation

meta-ros upstream has new commits on the `wrynose` branch. This update
pulls in the latest upstream changes.

## Impact

Pulls in upstream meta-ros changes. Patch compatibility has not been
verified automatically; manual review is required.

## TODO

- [ ] Verify that the following patches still apply cleanly:
  - `patches/0001-fix-Update-LAYERSERIES_COMPAT-to-adapt-to-upstream-u.patch`
  - `patches/0001-fix-remove-bbappend-and-patch-for-rosbag2-compressio.patch`
  - `patches/0001-jazzy-remove-outdated-bbappend-and-patches-of-stomp.patch`
  - `patches/0001-ros2-ament_cmake-add-python-configurations-for-class.patch`
  - `patches/0002-jazzy-update-libdir-of-ompl.patch`
  - `patches/0003-jazzy-move-some-nav2-and-moveit-packages-out-of-blac.patch`
  - `patches/Initial-commit-of-license.patch`
