### PR TITLE
ci(automation): update kas config from meta-qcom (master): 34175365960

### DIFF
--- a/ci/base.lock.yml
+++ b/ci/base.lock.yml
@@ -3,24 +3,24 @@ header:
 overrides:
     repos:
         oe-core:
-            commit: 62d2381bdee1cebb5924f8594f8a9994083d4f7d
+            commit: 09df3e534c4f38a033c514d7567006ed35cc34df
         bitbake:
-            commit: 3a99c26fa581d70ed67bd08a5e0e0d0b18369a7c
+            commit: 75c85c54d9bcc5b732459bef183bab79db00c843
         meta-arm:
-            commit: 28606c721503b70e8343968731a24260cfe985bc
+            commit: b0ff16aba48a197070daff28ef7ad67067fd3d88
         meta-openembedded:
-            commit: dc0ccaa27311b3379749ecf44f98c0b5e249902e
+            commit: f191557494e09df5a47bedcccdb6181cb8b6dbd4
         meta-virtualization:
-            commit: 022f4356d4a9b389f51472d40a9330aa59f6bb9a
+            commit: f45cc3787c11d040dbef8e7f956a4da420375829
         meta-audioreach:
-            commit: b5a382aba0e5b1e4cfbd9f36256ea46e0d4cf002
+            commit: 066142f374d074a0908afc14eb2c0bc6e1485611
         meta-selinux:
             commit: 7351443c6579671bcf048817438f1740ad23eaab
         meta-updater:
-            commit: fff4a58a057c26ec0a2067ea5f32acd75ef7add4
+            commit: 3f79539a8e1250c46d824b3af2415b9add945161
         meta-security:
-            commit: 226839ac408223f8041cde1b1d8b762d6fbc8050
+            commit: 0339b65f63877ed36fcffa44953e57c3bb969ca9
         meta-dpdk:
-            commit: ded70edc0937d939596a0c38b737af59afbb5e7b
+            commit: 6a59b0cd21084e33feb53b4f2d1310e49e1d4a83
         meta-ai:
-            commit: 60e38e2015f19058b467febd044f49bf70c4528f
+            commit: 3511d6c9669683fc232211eb72e1549d6db6e660

--- a/ci/base.yml
+++ b/ci/base.yml
@@ -18,6 +18,12 @@ repos:
       fix-igt-pause:
         repo: meta-qcom
         path: patches/oe-core/0001-igt-gpu-tools-fix-build-on-non-x86-platforms.patch
+      scons-variables-revert:
+        repo: meta-qcom
+        path: patches/oe-core/0002-python3-scons-backport-revert-of-the-4.11.0-Variables.patch
+      revert-python3-pycairo:
+        repo: meta-qcom
+        path: patches/oe-core/0001-Revert-python3-pycairo-inherit-python3-dir-not-pytho.patch
     layers:
       meta:
 
@@ -51,9 +57,6 @@ local_conf_header:
     "
   cmdline: |
     KERNEL_CMDLINE_EXTRA:append = " qcom_scm.download_mode=1"
-  qcomflash: |
-    IMAGE_CLASSES += "image_types_qcom"
-    IMAGE_FSTYPES += "qcomflash"
   extra: |
     DISTRO_FEATURES:append = " efi pam pni-names"
     EXTRA_IMAGE_FEATURES += "allow-empty-password empty-root-password allow-root-login"

--- a/ci/performance.yml
+++ b/ci/performance.yml
@@ -4,3 +4,4 @@ header:
 local_conf_header:
   cmdline-perf: |
     KERNEL_CMDLINE_EXTRA:append = " quiet systemd.tty.term.console=linux"
+    KERNEL_CMDLINE_EXTRA:append = "${@' initramfs.udev-root-only=1' if d.getVar('INITRAMFS_IMAGE') == 'initramfs-rootfs-image' else ''}"

--- a/ci/qcom-distro.yml
+++ b/ci/qcom-distro.yml
@@ -16,6 +16,10 @@ repos:
 
   meta-openembedded:
     url: https://github.com/openembedded/meta-openembedded
+    patches:
+      redis-install-prefix:
+        repo: meta-qcom
+        path: patches/meta-oe/0001-redis-fix-the-install-prefix-with-8.10.0.patch
     layers:
       meta-filesystems:
       meta-gnome:
@@ -37,6 +41,16 @@ repos:
 
   meta-selinux:
     url: https://git.yoctoproject.org/meta-selinux
+    patches:
+      libsepol-nativesdk:
+        repo: meta-qcom
+        path: patches/selinux/0001-libsepol-enable-nativesdk.patch
+      libselinux-nativesdk:
+        repo: meta-qcom
+        path: patches/selinux/0002-libselinux-enable-nativesdk.patch
+      libselinux-python-swig-4.5:
+        repo: meta-qcom
+        path: patches/selinux/0003-libselinux-python-fix-the-build-against-swig-4.5.0.patch
 
   meta-updater:
     url: https://github.com/uptane/meta-updater

--- a/ci/qcom-robotics-distro.yml
+++ b/ci/qcom-robotics-distro.yml
@@ -94,7 +94,9 @@ local_conf_header:
     PARALLEL_MAKE ?= "-j ${THREAD_COUNT} -l ${THREAD_COUNT}"
 
     '
-  meta_qcom_build_id: "META_QCOM_BUILD_ID = \"34175365960\"\n\n    "
+  os-release: |
+    META_QCOM_BUILD_ID = "34175365960"
+    OS_RELEASE_FIELDS:append = "META_QCOM_BUILD_ID"
   coinor_license_qa: "ERROR_QA:remove = \"license-format\"\n\n    "
 distro: qcom-robotics-ros2-jazzy
 target: qcom-robotics-image

--- a/ci/qcom-robotics-distro.yml
+++ b/ci/qcom-robotics-distro.yml
@@ -95,6 +95,6 @@ local_conf_header:
 
     '
   meta_qcom_build_id: "META_QCOM_BUILD_ID = \"34175365960\"\n\n    "
-  coinor_license_qa: "# Suppress license-format QA check for meta-ros coinor recipes\n    ERROR_QA:remove = \"license-format\"\n\n    "
+  coinor_license_qa: "ERROR_QA:remove = \"license-format\"\n\n    "
 distro: qcom-robotics-ros2-jazzy
 target: qcom-robotics-image

--- a/ci/qcom-robotics-distro.yml
+++ b/ci/qcom-robotics-distro.yml
@@ -10,11 +10,11 @@ repos:
     branch: main
   meta-qcom:
     url: https://github.com/qualcomm-linux/meta-qcom
-    commit: 36d23fedc4c84f2dee486857fc917f866506d047
+    commit: 7659417348e5fa189d31a2095313fa36bd7c0845
   meta-qcom-distro:
     url: https://github.com/qualcomm-linux/meta-qcom-distro
     branch: main
-    commit: 0fadc6b05fbacbbf11d0ff2b35f12491e196ba24
+    commit: d9d5a832de3159c0f4a3a934bf4bbfb31d452e4a
   oe-core:
     url: https://github.com/openembedded/openembedded-core
     layers:
@@ -23,7 +23,7 @@ repos:
       fix-BSD-license-missing:
         repo: meta-qcom-robotics-sdk
         path: patches/Initial-commit-of-license.patch
-    commit: 62d2381bdee1cebb5924f8594f8a9994083d4f7d
+    commit: 09df3e534c4f38a033c514d7567006ed35cc34df
   meta-ros:
     url: https://github.com/ros/meta-ros.git
     branch: master
@@ -94,5 +94,6 @@ local_conf_header:
     PARALLEL_MAKE ?= "-j ${THREAD_COUNT} -l ${THREAD_COUNT}"
 
     '
+  meta_qcom_build_id: "META_QCOM_BUILD_ID = \"34175365960\"\n\n    "
 distro: qcom-robotics-ros2-jazzy
 target: qcom-robotics-image

--- a/ci/qcom-robotics-distro.yml
+++ b/ci/qcom-robotics-distro.yml
@@ -95,5 +95,6 @@ local_conf_header:
 
     '
   meta_qcom_build_id: "META_QCOM_BUILD_ID = \"34175365960\"\n\n    "
+  coinor_license_qa: "# Suppress license-format QA check for meta-ros coinor recipes\n    ERROR_QA:remove = \"license-format\"\n\n    "
 distro: qcom-robotics-ros2-jazzy
 target: qcom-robotics-image

--- a/recipes-devtools/python/python3-distlib_0.3.8.bbappend
+++ b/recipes-devtools/python/python3-distlib_0.3.8.bbappend
@@ -1,0 +1,1 @@
+DEPENDS:append = " python3-wheel-native"


### PR DESCRIPTION
CRs-Fixed: 4671821

## Auto-update kas config from meta-qcom nightly build (master)

This pull request automatically updates kas config from the latest meta-qcom master nightly build.

**Build Details:**
- meta-qcom nightly build url: https://github.com/qualcomm-linux/meta-qcom/actions/runs/34175365960
- Check and download actions url: (local run of the meta-layers-update skill on szebldarm02)
- Timestamp: Tue Sep  8 06:24:43 AM UTC 2026