### PR TITLE
ci(automation): update kas config from meta-qcom (wrynose): 34170020712

### DIFF
--- a/ci/base.lock.yml
+++ b/ci/base.lock.yml
@@ -3,17 +3,17 @@ header:
 overrides:
     repos:
         oe-core:
-            commit: f09a0f28aeb54ddd90415dd458338e1565bb5a49
+            commit: ef022bf82d79015802309d14c28b13373ebe53f5
         meta-lts-mixins:
-            commit: 6ad95d00531b32ec01792ab496718943dc95277b
+            commit: 8bfc4ae8cf7fc835a23d7a27830f866617d9808f
         bitbake:
-            commit: fae9db3168dbff1b8c76fe9c6726a9687ff97514
+            commit: 0ad6c1c34a5e07a5f8dd66ab248c1e7b37b69fa9
         meta-arm:
             commit: 0979b80429099f1a42dc0026c8c466cee780bc74
         meta-openembedded:
-            commit: 6bf0d8ad57b33950bab4c7f6c037e1ccb6f6e2eb
+            commit: 14282a02be9c74a1276a7cda7d6c89e054699a11
         meta-virtualization:
-            commit: ff03b1e118c4788f17d7ae45b820b00e3194634a
+            commit: aab9c1a0dd6b48776c9f372a32c32486c560b9c9
         meta-audioreach:
             commit: 3f673ee6f52bfeda69205078a99e89cd501015b4
         meta-selinux:
@@ -24,3 +24,5 @@ overrides:
             commit: c0d1d6200e7a84c39fb940cb1f22aad4b0b3d808
         meta-dpdk:
             commit: 6a59b0cd21084e33feb53b4f2d1310e49e1d4a83
+        meta-ai:
+            commit: 60e38e2015f19058b467febd044f49bf70c4528f

--- a/ci/base.yml
+++ b/ci/base.yml
@@ -52,9 +52,6 @@ local_conf_header:
     "
   cmdline: |
     KERNEL_CMDLINE_EXTRA:append = " qcom_scm.download_mode=1"
-  qcomflash: |
-    IMAGE_CLASSES += "image_types_qcom"
-    IMAGE_FSTYPES += "qcomflash"
   extra: |
     DISTRO_FEATURES:append = " efi pam pni-names"
     EXTRA_IMAGE_FEATURES += "allow-empty-password empty-root-password allow-root-login"

--- a/ci/qcom-distro.yml
+++ b/ci/qcom-distro.yml
@@ -24,6 +24,10 @@ repos:
       meta-python:
       meta-xfce:
 
+  meta-ai:
+    url: https://github.com/qualcomm-linux/meta-ai
+    branch: main
+
   meta-virtualization:
     url: https://git.yoctoproject.org/meta-virtualization
 

--- a/ci/qcom-robotics-distro.yml
+++ b/ci/qcom-robotics-distro.yml
@@ -10,7 +10,7 @@ repos:
     branch: wrynose
   meta-qcom:
     url: https://github.com/qualcomm-linux/meta-qcom
-    commit: f415a09a64e1a282fe9ca1efa47b911caaffe1b8
+    commit: dd4b8eeeb7c10e85825c71e4d6aa4eb2017b7ece
   oe-core:
     url: https://github.com/openembedded/openembedded-core
     layers:
@@ -19,7 +19,7 @@ repos:
       fix-BSD-license-missing:
         repo: meta-qcom-robotics-sdk
         path: patches/Initial-commit-of-license.patch
-    commit: f09a0f28aeb54ddd90415dd458338e1565bb5a49
+    commit: ef022bf82d79015802309d14c28b13373ebe53f5
   meta-ros:
     url: https://github.com/ros/meta-ros.git
     branch: wrynose
@@ -45,7 +45,7 @@ repos:
         path: patches/0001-fix-remove-bbappend-and-patch-for-rosbag2-compressio.patch
     commit: c671acf8a948e22a614a6d6d1dcf18bdf4113df5
   meta-qcom-distro:
-    commit: 55aae963e53a82c637fcd4f9ed58108252b0346c
+    commit: 84630875c2f761160aaa33fa79d7b885d67ced1e
 local_conf_header:
   resource_limitation: '# Capture the count of cpu cores available from the host.
 
@@ -100,5 +100,8 @@ local_conf_header:
     PREFERRED_VERSION_libcamera = "1:0.6.0"
 
     '
+  os-release: |
+    META_QCOM_BUILD_ID = "34170020712"
+    OS_RELEASE_FIELDS:append = "META_QCOM_BUILD_ID"
 distro: qcom-robotics-ros2-jazzy
 target: qcom-robotics-image


### PR DESCRIPTION
CRs-Fixed: 4671822
## Auto-update kas config from meta-qcom nightly build (wrynose)

This pull request automatically updates kas config from the latest meta-qcom wrynose nightly build.

**Build Details:**
- meta-qcom nightly build url: https://github.com/qualcomm-linux/meta-qcom/actions/runs/34170020712
- Check and download actions url: (local run of the meta-layers-update skill on szebldarm02)
- Timestamp: Tue Sep  8 06:38:59 AM UTC 2026