### PR TITLE
fix: bump qrb-ros-video version

### DIFF
--- a/recipes/qrb-ros-video/qrb-ros-video_0.1.7.bb
+++ b/recipes/qrb-ros-video/qrb-ros-video_0.1.7.bb
@@ -66,7 +66,7 @@ RDEPENDS:${PN} += "${ROS_EXEC_DEPENDS}"
 SRC_URI = "git://github.com/quic-qrb-ros/qrb_ros_video.git;protocol=https;branch=stable/0.1.7 \
            file://0002-fix-test-add-mp4-extension-fallback-when-discoverer-fail-29.patch;striplevel=2 \
            "
-SRCREV = "706839334db5247bcb3aee240c46c74b146ba0af"
+SRCREV = "4cf038f0dec6154ae464c904cf7e7f24b125be7b"
 S = "${UNPACKDIR}/${BP}/qrb_ros_video"
 PV = "0.1.7"
 

--- a/recipes/qrb-ros-video/qrb-video-v4l2-lib_0.1.7.bb
+++ b/recipes/qrb-ros-video/qrb-video-v4l2-lib_0.1.7.bb
@@ -13,7 +13,7 @@ DEPENDS = "glog gflags"
 
 SRC_URI = "git://github.com/quic-qrb-ros/qrb_ros_video.git;protocol=https;branch=stable/0.1.7"
 
-SRCREV = "706839334db5247bcb3aee240c46c74b146ba0af"
+SRCREV = "4cf038f0dec6154ae464c904cf7e7f24b125be7b"
 S = "${UNPACKDIR}/${BP}/qrb_video_v4l2_lib"
 
 EXTRA_OECMAKE:append = " -DBUILD_TESTING=OFF"


### PR DESCRIPTION
CRs-Fixed: 4674622

Includes upstream changes:
    **fix(v4l2): propagate input resolution to output port format (#41)**

    Motivation:
    
    Ensure the output port format inherits width and height from the input port when setting the codec format, preventing potential resolution mismatch between input and output configurations. Otherwise, capture port may be set wrong resolution and trigger downscaling for encoding.

    Impact:
    
    With this change, encoder can start and function with correct resolution.
